### PR TITLE
feat: CLI polish, README, MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 hishamank
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,85 +1,167 @@
-# ClawOps v0.1
+<p align="center">
+  <h1 align="center">ClawOps</h1>
+  <p align="center">Monitor, manage, and orchestrate your AI agents from a single control plane.</p>
+</p>
 
-Agent operations dashboard — monitor, manage, and orchestrate your AI agents from a single control plane.
+<p align="center">
+  <a href="https://github.com/hishamank/clawops/actions"><img src="https://img.shields.io/github/actions/workflow/status/hishamank/clawops/ci.yml?branch=main&style=flat-square" alt="Build Status"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="License"></a>
+  <a href="https://github.com/hishamank/clawops/releases"><img src="https://img.shields.io/badge/version-0.1.0-green?style=flat-square" alt="Version"></a>
+</p>
+
+---
 
 ## Architecture
 
 ```
-┌─────────────────────────────────────────────────────┐
-│                   ClawOps Monorepo                   │
-├─────────────┬──────────────────┬────────────────────┤
-│             │                  │                    │
-│  packages/  │   packages/      │   packages/        │
-│    cli      │     api          │     web            │
-│             │                  │                    │
-│  Commander  │  Fastify         │  Next.js 15        │
-│  CLI tool   │  REST API        │  App Router        │
-│             │  Drizzle ORM     │  shadcn/ui         │
-│             │  SQLite          │  Tailwind v4       │
-│             │                  │                    │
-│  clawops    │  :3001           │  :3000             │
-│  agent *    │  /api/agents     │  /                 │
-│  run *      │  /api/runs       │  /agents           │
-│             │  /health         │  /agents/[id]      │
-│             │                  │  /runs             │
-└──────┬──────┴────────┬─────────┴─────────┬──────────┘
-       │               │                   │
-       └───── HTTP ────┘                   │
-                       └───── HTTP ────────┘
+                         ┌──────────────────────────┐
+                         │       ClawOps CLI         │
+                         │    $ clawops agent ...    │
+                         │    $ clawops runs list    │
+                         └────────────┬─────────────┘
+                                      │ HTTP
+                                      ▼
+┌─────────────────────┐    ┌──────────────────────────┐    ┌──────────────────┐
+│   ClawOps Web UI    │───▶│     ClawOps API          │◀──▶│     SQLite       │
+│   Next.js 15        │    │     Fastify + Drizzle    │    │   (clawops.db)   │
+│   :3000             │    │     :3001                │    └──────────────────┘
+└─────────────────────┘    └──────────────────────────┘
 ```
 
-## Setup
+## What is ClawOps?
+
+ClawOps is an open-source agent operations platform. It provides a REST API, web dashboard, and CLI for registering AI agents, launching task runs, and tracking their status in real time. Built as a TypeScript monorepo with Fastify, Next.js 15, and SQLite.
+
+## Quick Start
 
 ```bash
-# Install dependencies
+# 1. Clone the repository
+git clone https://github.com/hishamank/clawops.git && cd clawops
+
+# 2. Install dependencies
 pnpm install
 
-# Generate database migrations
-pnpm --filter @clawops/api db:generate
-
-# Push database schema
+# 3. Set up the database
 pnpm --filter @clawops/api db:push
 
-# Start all packages in dev mode
+# 4. Start all services in development mode
 pnpm dev
+
+# 5. Open the dashboard
+open http://localhost:3000
 ```
-
-## Packages
-
-| Package | Description | Port |
-|---------|-------------|------|
-| `@clawops/api` | REST API server (Fastify + Drizzle + SQLite) | 3001 |
-| `@clawops/web` | Dashboard UI (Next.js 15 + shadcn/ui) | 3000 |
-| `@clawops/cli` | CLI tool (`clawops`) | — |
 
 ## CLI Usage
 
 ```bash
 # Register an agent
-clawops agent register --name "my-agent"
+$ clawops agent register --name "doc-processor"
+✓ Agent registered successfully
+  ID:     a1b2c3d4-e5f6-7890-abcd-ef1234567890
+  Name:   doc-processor
+  Status: offline
 
-# Update agent status
-clawops agent status --id <agent-id> --status online
+# Set agent online
+$ clawops agent status --id a1b2c3d4 --status online
+✓ Agent a1b2c3d4 status → online
 
 # Start a run
-clawops run start --agent <agent-id> --task "Process documents"
+$ clawops run start --agent a1b2c3d4 --task "Process Q4 reports"
+✓ Run started
+  Run ID: f9e8d7c6-b5a4-3210-fedc-ba0987654321
+  Agent:  a1b2c3d4-e5f6-7890-abcd-ef1234567890
+  Task:   Process Q4 reports
+  Status: running
+
+# List runs (table output)
+$ clawops runs list
+Found 3 run(s)
+
+┌──────────┬──────────┬──────────────────────┬───────────┬─────────────────────┬──────────┐
+│ ID       │ Agent    │ Task                 │ Status    │ Started             │ Duration │
+├──────────┼──────────┼──────────────────────┼───────────┼─────────────────────┼──────────┤
+│ f9e8d7c6 │ a1b2c3d4 │ Process Q4 reports   │ running   │ 3/1/2026, 10:00 AM  │ 12s      │
+│ 11223344 │ a1b2c3d4 │ Analyze user data    │ completed │ 3/1/2026, 9:30 AM   │ 2m 15s   │
+│ 55667788 │ bbccddee │ Generate summaries   │ failed    │ 3/1/2026, 9:00 AM   │ 45s      │
+└──────────┴──────────┴──────────────────────┴───────────┴─────────────────────┴──────────┘
 
 # Finish a run
-clawops run finish --id <run-id> --output "Processed 42 documents"
+$ clawops run finish --id f9e8d7c6 --output "Processed 42 documents"
+✓ Run f9e8d7c6 finished — completed
 
-# List runs
-clawops runs list --agent <agent-id> --status completed
+# JSON output for scripting
+$ clawops runs list --json
+[{"id":"f9e8d7c6-...","agentId":"a1b2c3d4-...","task":"Process Q4 reports",...}]
+
+# Configure API endpoint
+$ clawops config set --api-url https://clawops.example.com
+✓ Configuration saved
+  API URL: https://clawops.example.com
+
+$ clawops config get
+ClawOps Configuration
+  API URL: https://clawops.example.com
+  (from ~/.clawops/config.json)
 ```
+
+## API Endpoints
+
+| Method  | Endpoint              | Description              |
+|---------|-----------------------|--------------------------|
+| `GET`   | `/health`             | Health check             |
+| `GET`   | `/api/agents`         | List all agents          |
+| `POST`  | `/api/agents`         | Register a new agent     |
+| `PATCH` | `/api/agents/:id`     | Update agent status      |
+| `GET`   | `/api/runs`           | List runs (filterable)   |
+| `POST`  | `/api/runs`           | Start a new run          |
+| `PATCH` | `/api/runs/:id`       | Update / finish a run    |
+| `GET`   | `/api/agents/:id/runs`| List runs for an agent   |
+
+## Docker Setup
+
+```bash
+# Build and run with Docker Compose
+docker compose up -d
+
+# Or build individual images
+docker build -t clawops-api -f packages/api/Dockerfile .
+docker build -t clawops-web -f packages/web/Dockerfile .
+```
+
+| Service | Port | Description        |
+|---------|------|--------------------|
+| `api`   | 3001 | REST API server    |
+| `web`   | 3000 | Dashboard UI       |
+
+## Packages
+
+| Package          | Description                              |
+|------------------|------------------------------------------|
+| `@clawops/api`   | Fastify REST API + Drizzle ORM + SQLite  |
+| `@clawops/web`   | Next.js 15 dashboard with Tailwind v4    |
+| `@clawops/cli`   | CLI tool (`clawops`)                     |
 
 ## Development
 
 ```bash
-pnpm dev          # Start all packages
+pnpm dev          # Start all packages in dev mode
 pnpm build        # Build all packages
 pnpm lint         # Lint all packages
 pnpm typecheck    # Type-check all packages
 ```
 
+## Contributing
+
+Contributions are welcome! Please follow these steps:
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feat/my-feature`)
+3. Commit your changes (`git commit -m 'feat: add my feature'`)
+4. Push to the branch (`git push origin feat/my-feature`)
+5. Open a Pull Request
+
+Please use [conventional commits](https://www.conventionalcommits.org/) for commit messages.
+
 ## License
 
-MIT
+[MIT](LICENSE) &copy; 2026 hishamank

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "clawops",
+  "version": "0.1.0",
   "private": true,
   "scripts": {
     "dev": "turbo dev",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,6 +12,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "chalk": "^5.6.2",
+    "cli-table3": "^0.6.5",
     "commander": "^13.1.0"
   },
   "devDependencies": {

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -1,4 +1,4 @@
-const API_URL = process.env.CLAWOPS_API_URL ?? "http://localhost:3001";
+import { getApiUrl } from "./config.js";
 
 interface ApiError {
   error: string;
@@ -8,7 +8,8 @@ export async function request<T>(
   path: string,
   options?: RequestInit,
 ): Promise<T> {
-  const res = await fetch(`${API_URL}${path}`, {
+  const apiUrl = getApiUrl();
+  const res = await fetch(`${apiUrl}${path}`, {
     ...options,
     headers: {
       "Content-Type": "application/json",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 import { Command } from "commander";
+import chalk from "chalk";
+import Table from "cli-table3";
 import {
   registerAgent,
   updateAgentStatus,
@@ -8,6 +10,59 @@ import {
   finishRun,
   listRuns,
 } from "./api.js";
+import { loadConfig, saveConfig } from "./config.js";
+
+function statusColor(status: string): string {
+  switch (status) {
+    case "online":
+    case "completed":
+      return chalk.green(status);
+    case "running":
+      return chalk.blue(status);
+    case "pending":
+      return chalk.yellow(status);
+    case "failed":
+    case "error":
+      return chalk.red(status);
+    case "offline":
+      return chalk.gray(status);
+    default:
+      return status;
+  }
+}
+
+function truncate(str: string, len: number): string {
+  if (str.length <= len) return str;
+  return str.slice(0, len - 1) + "…";
+}
+
+function formatDuration(startedAt: string, finishedAt: string | null): string {
+  const start = new Date(startedAt).getTime();
+  const end = finishedAt ? new Date(finishedAt).getTime() : Date.now();
+  const ms = end - start;
+  const secs = Math.floor(ms / 1000);
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  const remSecs = secs % 60;
+  if (mins < 60) return `${mins}m ${remSecs}s`;
+  const hrs = Math.floor(mins / 60);
+  const remMins = mins % 60;
+  return `${hrs}h ${remMins}m`;
+}
+
+function formatTime(iso: string): string {
+  return new Date(iso).toLocaleString();
+}
+
+function handleError(e: unknown, json: boolean): never {
+  const message = e instanceof Error ? e.message : "Unknown error";
+  if (json) {
+    console.log(JSON.stringify({ error: message }));
+  } else {
+    console.error(chalk.red(`Error: ${message}`));
+  }
+  process.exit(1);
+}
 
 const program = new Command();
 
@@ -16,23 +71,28 @@ program
   .description("ClawOps — agent operations CLI")
   .version("0.1.0");
 
+// ── agent commands ──────────────────────────────────────────────
+
 const agent = program.command("agent").description("Manage agents");
 
 agent
   .command("register")
   .description("Register a new agent")
   .requiredOption("--name <name>", "Agent name")
-  .action(async (opts: { name: string }) => {
+  .option("--json", "Output as JSON")
+  .action(async (opts: { name: string; json?: boolean }) => {
     try {
       const result = await registerAgent(opts.name);
-      console.log(`Agent registered: ${result.id}`);
-      console.log(`  Name:   ${result.name}`);
-      console.log(`  Status: ${result.status}`);
+      if (opts.json) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+      console.log(chalk.green("✓") + " Agent registered successfully");
+      console.log(`  ${chalk.bold("ID:")}     ${result.id}`);
+      console.log(`  ${chalk.bold("Name:")}   ${result.name}`);
+      console.log(`  ${chalk.bold("Status:")} ${statusColor(result.status)}`);
     } catch (e) {
-      console.error(
-        `Error: ${e instanceof Error ? e.message : "Unknown error"}`,
-      );
-      process.exit(1);
+      handleError(e, !!opts.json);
     }
   });
 
@@ -41,17 +101,24 @@ agent
   .description("Update agent status")
   .requiredOption("--id <id>", "Agent ID")
   .requiredOption("--status <status>", "New status (online|offline|error)")
-  .action(async (opts: { id: string; status: string }) => {
+  .option("--json", "Output as JSON")
+  .action(async (opts: { id: string; status: string; json?: boolean }) => {
     try {
       const result = await updateAgentStatus(opts.id, opts.status);
-      console.log(`Agent ${result.id} status updated to: ${result.status}`);
-    } catch (e) {
-      console.error(
-        `Error: ${e instanceof Error ? e.message : "Unknown error"}`,
+      if (opts.json) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+      console.log(
+        chalk.green("✓") +
+          ` Agent ${chalk.bold(result.id.slice(0, 8))} status → ${statusColor(result.status)}`,
       );
-      process.exit(1);
+    } catch (e) {
+      handleError(e, !!opts.json);
     }
   });
+
+// ── run commands ────────────────────────────────────────────────
 
 const run = program.command("run").description("Manage runs");
 
@@ -60,20 +127,25 @@ run
   .description("Start a new run")
   .requiredOption("--agent <id>", "Agent ID")
   .requiredOption("--task <description>", "Task description")
-  .action(async (opts: { agent: string; task: string }) => {
-    try {
-      const result = await startRun(opts.agent, opts.task);
-      console.log(`Run started: ${result.id}`);
-      console.log(`  Agent: ${result.agentId}`);
-      console.log(`  Task:  ${result.task}`);
-      console.log(`  Status: ${result.status}`);
-    } catch (e) {
-      console.error(
-        `Error: ${e instanceof Error ? e.message : "Unknown error"}`,
-      );
-      process.exit(1);
-    }
-  });
+  .option("--json", "Output as JSON")
+  .action(
+    async (opts: { agent: string; task: string; json?: boolean }) => {
+      try {
+        const result = await startRun(opts.agent, opts.task);
+        if (opts.json) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+        console.log(chalk.green("✓") + " Run started");
+        console.log(`  ${chalk.bold("Run ID:")} ${result.id}`);
+        console.log(`  ${chalk.bold("Agent:")}  ${result.agentId}`);
+        console.log(`  ${chalk.bold("Task:")}   ${result.task}`);
+        console.log(`  ${chalk.bold("Status:")} ${statusColor(result.status)}`);
+      } catch (e) {
+        handleError(e, !!opts.json);
+      }
+    },
+  );
 
 run
   .command("finish")
@@ -81,24 +153,39 @@ run
   .requiredOption("--id <run-id>", "Run ID")
   .requiredOption("--output <output>", "Run output")
   .option("--error [error]", "Error message (marks run as failed)")
-  .action(async (opts: { id: string; output: string; error?: string }) => {
-    try {
-      const result = await finishRun(
-        opts.id,
-        opts.output,
-        typeof opts.error === "string" ? opts.error : undefined,
-      );
-      console.log(`Run ${result.id} finished`);
-      console.log(`  Status: ${result.status}`);
-      if (result.output) console.log(`  Output: ${result.output}`);
-      if (result.error) console.log(`  Error:  ${result.error}`);
-    } catch (e) {
-      console.error(
-        `Error: ${e instanceof Error ? e.message : "Unknown error"}`,
-      );
-      process.exit(1);
-    }
-  });
+  .option("--json", "Output as JSON")
+  .action(
+    async (opts: {
+      id: string;
+      output: string;
+      error?: string;
+      json?: boolean;
+    }) => {
+      try {
+        const result = await finishRun(
+          opts.id,
+          opts.output,
+          typeof opts.error === "string" ? opts.error : undefined,
+        );
+        if (opts.json) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+        console.log(
+          chalk.green("✓") +
+            ` Run ${chalk.bold(result.id.slice(0, 8))} finished — ${statusColor(result.status)}`,
+        );
+        if (result.output)
+          console.log(`  ${chalk.bold("Output:")} ${result.output}`);
+        if (result.error)
+          console.log(`  ${chalk.bold("Error:")}  ${chalk.red(result.error)}`);
+      } catch (e) {
+        handleError(e, !!opts.json);
+      }
+    },
+  );
+
+// ── runs list ───────────────────────────────────────────────────
 
 const runs = program.command("runs").description("List runs");
 
@@ -107,30 +194,105 @@ runs
   .description("List runs")
   .option("--agent <id>", "Filter by agent ID")
   .option("--status <status>", "Filter by status")
-  .action(async (opts: { agent?: string; status?: string }) => {
+  .option("--json", "Output as JSON")
+  .action(
+    async (opts: { agent?: string; status?: string; json?: boolean }) => {
+      try {
+        const results = await listRuns(opts);
+        if (opts.json) {
+          console.log(JSON.stringify(results, null, 2));
+          return;
+        }
+        if (results.length === 0) {
+          console.log(chalk.yellow("No runs found"));
+          return;
+        }
+        console.log(
+          chalk.bold(`Found ${results.length} run(s)`) + "\n",
+        );
+        const table = new Table({
+          head: ["ID", "Agent", "Task", "Status", "Started", "Duration"],
+          style: { head: ["cyan"] },
+        });
+        for (const r of results) {
+          table.push([
+            r.id.slice(0, 8),
+            r.agentId.slice(0, 8),
+            truncate(r.task, 40),
+            statusColor(r.status),
+            formatTime(r.startedAt),
+            formatDuration(r.startedAt, r.finishedAt),
+          ]);
+        }
+        console.log(table.toString());
+      } catch (e) {
+        handleError(e, !!opts.json);
+      }
+    },
+  );
+
+// ── config commands ─────────────────────────────────────────────
+
+const config = program.command("config").description("Manage configuration");
+
+config
+  .command("set")
+  .description("Set a configuration value")
+  .requiredOption("--api-url <url>", "API server URL")
+  .option("--json", "Output as JSON")
+  .action(async (opts: { apiUrl: string; json?: boolean }) => {
     try {
-      const results = await listRuns(opts);
-      if (results.length === 0) {
-        console.log("No runs found");
+      const cfg = loadConfig();
+      cfg.apiUrl = opts.apiUrl;
+      saveConfig(cfg);
+      if (opts.json) {
+        console.log(JSON.stringify(cfg, null, 2));
         return;
       }
-      console.log(`Found ${results.length} run(s):\n`);
-      for (const r of results) {
-        console.log(`  ${r.id}`);
-        console.log(`    Task:    ${r.task}`);
-        console.log(`    Status:  ${r.status}`);
-        console.log(`    Agent:   ${r.agentId}`);
-        console.log(`    Started: ${r.startedAt}`);
-        if (r.finishedAt) console.log(`    Finished: ${r.finishedAt}`);
-        if (r.output) console.log(`    Output:  ${r.output}`);
-        if (r.error) console.log(`    Error:   ${r.error}`);
-        console.log();
+      console.log(chalk.green("✓") + " Configuration saved");
+      console.log(`  ${chalk.bold("API URL:")} ${cfg.apiUrl}`);
+    } catch (e) {
+      handleError(e, !!opts.json);
+    }
+  });
+
+config
+  .command("get")
+  .description("Show current configuration")
+  .option("--json", "Output as JSON")
+  .action(async (opts: { json?: boolean }) => {
+    try {
+      const cfg = loadConfig();
+      const apiUrl =
+        process.env.CLAWOPS_API_URL ?? cfg.apiUrl ?? "http://localhost:3001";
+      if (opts.json) {
+        console.log(
+          JSON.stringify(
+            {
+              apiUrl,
+              source: process.env.CLAWOPS_API_URL
+                ? "env"
+                : cfg.apiUrl
+                  ? "config"
+                  : "default",
+            },
+            null,
+            2,
+          ),
+        );
+        return;
+      }
+      console.log(chalk.bold("ClawOps Configuration\n"));
+      console.log(`  ${chalk.bold("API URL:")} ${apiUrl}`);
+      if (process.env.CLAWOPS_API_URL) {
+        console.log(`  ${chalk.gray("(from CLAWOPS_API_URL env var)")}`);
+      } else if (cfg.apiUrl) {
+        console.log(`  ${chalk.gray("(from ~/.clawops/config.json)")}`);
+      } else {
+        console.log(`  ${chalk.gray("(default)")}`);
       }
     } catch (e) {
-      console.error(
-        `Error: ${e instanceof Error ? e.message : "Unknown error"}`,
-      );
-      process.exit(1);
+      handleError(e, !!opts.json);
     }
   });
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,0 +1,31 @@
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+export interface ClawOpsConfig {
+  apiUrl?: string;
+}
+
+const CONFIG_DIR = join(homedir(), ".clawops");
+const CONFIG_FILE = join(CONFIG_DIR, "config.json");
+
+export function loadConfig(): ClawOpsConfig {
+  try {
+    const raw = readFileSync(CONFIG_FILE, "utf-8");
+    return JSON.parse(raw) as ClawOpsConfig;
+  } catch {
+    return {};
+  }
+}
+
+export function saveConfig(config: ClawOpsConfig): void {
+  mkdirSync(CONFIG_DIR, { recursive: true });
+  writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2) + "\n");
+}
+
+export function getApiUrl(): string {
+  const envUrl = process.env.CLAWOPS_API_URL;
+  if (envUrl) return envUrl;
+  const config = loadConfig();
+  return config.apiUrl ?? "http://localhost:3001";
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,12 @@ importers:
 
   packages/cli:
     dependencies:
+      chalk:
+        specifier: ^5.6.2
+        version: 5.6.2
+      cli-table3:
+        specifier: ^0.6.5
+        version: 0.6.5
       commander:
         specifier: ^13.1.0
         version: 13.1.0
@@ -113,6 +119,10 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@colors/colors@1.5.0':
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
+    engines: {node: '>=0.1.90'}
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -977,6 +987,10 @@ packages:
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -1026,11 +1040,19 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
+  cli-table3@0.6.5:
+    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
+    engines: {node: 10.* || >= 12.*}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -1187,6 +1209,9 @@ packages:
         optional: true
       sqlite3:
         optional: true
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -1383,6 +1408,10 @@ packages:
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -1750,8 +1779,16 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -1893,6 +1930,9 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@colors/colors@1.5.0':
+    optional: true
 
   '@drizzle-team/brocli@0.10.2': {}
 
@@ -2474,6 +2514,8 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  ansi-regex@5.0.1: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
@@ -2527,11 +2569,19 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chalk@5.6.2: {}
+
   chownr@1.1.4: {}
 
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
+
+  cli-table3@0.6.5:
+    dependencies:
+      string-width: 4.2.3
+    optionalDependencies:
+      '@colors/colors': 1.5.0
 
   client-only@0.0.1: {}
 
@@ -2589,6 +2639,8 @@ snapshots:
       '@types/react': 19.2.14
       better-sqlite3: 11.10.0
       react: 19.2.4
+
+  emoji-regex@8.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -2881,6 +2933,8 @@ snapshots:
   ipaddr.js@2.3.0: {}
 
   is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-glob@4.0.3:
     dependencies:
@@ -3239,9 +3293,19 @@ snapshots:
 
   split2@4.2.0: {}
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
 
   strip-json-comments@2.0.1: {}
 


### PR DESCRIPTION
## Summary
Final polish pass — CLI UX, project docs, and licensing.

## Changes
- `feat(cli)`: colored output (chalk), table formatting (cli-table3), --json flag on all commands, `clawops config set/get`, proper exit codes
- `docs`: rewrote root README — architecture diagram, quick start, CLI examples, API table, Docker instructions, contributing guide
- `chore`: MIT LICENSE file, version bumped to 0.1.0 across all packages

## Review Checklist
- [ ] CLI table output is clean and readable
- [ ] --json flag works on all commands
- [ ] clawops config saves/reads from ~/.clawops/config.json
- [ ] README is clear for a first-time contributor
- [ ] License is correct