### PR TITLE
chore: build packages/shared — types, constants, model pricing, utils (#13)

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,12 +4,16 @@
   "private": true,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "scripts": {
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "typescript": "^5.7.0"
   }
 }

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1,0 +1,81 @@
+export const AgentStatus = {
+  online: "online",
+  idle: "idle",
+  busy: "busy",
+  offline: "offline",
+} as const;
+
+export type AgentStatus = (typeof AgentStatus)[keyof typeof AgentStatus];
+
+export const TaskStatus = {
+  backlog: "backlog",
+  todo: "todo",
+  "in-progress": "in-progress",
+  review: "review",
+  done: "done",
+  cancelled: "cancelled",
+} as const;
+
+export type TaskStatus = (typeof TaskStatus)[keyof typeof TaskStatus];
+
+export const TaskPriority = {
+  low: "low",
+  medium: "medium",
+  high: "high",
+  urgent: "urgent",
+} as const;
+
+export type TaskPriority = (typeof TaskPriority)[keyof typeof TaskPriority];
+
+export const ProjectStatus = {
+  planning: "planning",
+  active: "active",
+  paused: "paused",
+  done: "done",
+} as const;
+
+export type ProjectStatus = (typeof ProjectStatus)[keyof typeof ProjectStatus];
+
+export const MilestoneStatus = {
+  pending: "pending",
+  done: "done",
+} as const;
+
+export type MilestoneStatus =
+  (typeof MilestoneStatus)[keyof typeof MilestoneStatus];
+
+export const HabitType = {
+  heartbeat: "heartbeat",
+  scheduled: "scheduled",
+  cron: "cron",
+  hook: "hook",
+  watchdog: "watchdog",
+  polling: "polling",
+} as const;
+
+export type HabitType = (typeof HabitType)[keyof typeof HabitType];
+
+export const HabitStatus = {
+  active: "active",
+  paused: "paused",
+} as const;
+
+export type HabitStatus = (typeof HabitStatus)[keyof typeof HabitStatus];
+
+export const IdeaStatus = {
+  raw: "raw",
+  reviewed: "reviewed",
+  promoted: "promoted",
+  archived: "archived",
+} as const;
+
+export type IdeaStatus = (typeof IdeaStatus)[keyof typeof IdeaStatus];
+
+export const Source = {
+  human: "human",
+  agent: "agent",
+  cli: "cli",
+  script: "script",
+} as const;
+
+export type Source = (typeof Source)[keyof typeof Source];

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,1 +1,4 @@
-export {};
+export * from "./constants.js";
+export * from "./modelPricing.js";
+export * from "./utils.js";
+export * from "./types.js";

--- a/packages/shared/src/modelPricing.ts
+++ b/packages/shared/src/modelPricing.ts
@@ -1,0 +1,26 @@
+export interface ModelPricing {
+  inputPer1M: number;
+  outputPer1M: number;
+}
+
+const MODEL_PRICING: Record<string, ModelPricing> = {
+  "claude-opus-4-6": { inputPer1M: 15.0, outputPer1M: 75.0 },
+  "claude-sonnet-4-6": { inputPer1M: 3.0, outputPer1M: 15.0 },
+  "claude-haiku-4-5": { inputPer1M: 0.25, outputPer1M: 1.25 },
+  "gpt-4o": { inputPer1M: 5.0, outputPer1M: 15.0 },
+  "gpt-4o-mini": { inputPer1M: 0.15, outputPer1M: 0.6 },
+  llama3: { inputPer1M: 0, outputPer1M: 0 },
+  "qwen2.5": { inputPer1M: 0, outputPer1M: 0 },
+  "gemini-2.0-flash": { inputPer1M: 0.1, outputPer1M: 0.4 },
+};
+
+const OLLAMA_DEFAULT: ModelPricing = { inputPer1M: 0, outputPer1M: 0 };
+
+export function getModelPricing(model: string): ModelPricing {
+  const exact = MODEL_PRICING[model];
+  if (exact) return exact;
+
+  if (model.startsWith("ollama/")) return OLLAMA_DEFAULT;
+
+  return { inputPer1M: 0, outputPer1M: 0 };
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,0 +1,14 @@
+export interface PaginationParams {
+  limit: number;
+  offset: number;
+}
+
+export interface PaginatedResult<T> {
+  data: T[];
+  total: number;
+}
+
+export interface ApiErrorResponse {
+  error: string;
+  code: string;
+}

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -1,0 +1,40 @@
+import crypto from "node:crypto";
+import { getModelPricing } from "./modelPricing.js";
+
+const ALPHABET =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-";
+const ID_LENGTH = 21;
+
+export function generateId(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(ID_LENGTH));
+  let id = "";
+  for (let i = 0; i < ID_LENGTH; i++) {
+    id += ALPHABET[bytes[i] & 63];
+  }
+  return id;
+}
+
+export function hashApiKey(key: string): string {
+  return crypto.createHash("sha256").update(key).digest("hex");
+}
+
+export function verifyApiKey(key: string, hash: string): boolean {
+  const computed = hashApiKey(key);
+  return crypto.timingSafeEqual(Buffer.from(computed), Buffer.from(hash));
+}
+
+export function formatCost(cost: number): string {
+  return `$${cost.toFixed(4)}`;
+}
+
+export function calcCost(
+  model: string,
+  tokensIn: number,
+  tokensOut: number,
+): number {
+  const pricing = getModelPricing(model);
+  return (
+    (tokensIn / 1_000_000) * pricing.inputPer1M +
+    (tokensOut / 1_000_000) * pricing.outputPer1M
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
 
   packages/shared:
     devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.13
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -827,8 +830,8 @@ packages:
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
-  '@types/node@25.3.3':
-    resolution: {integrity: sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==}
+  '@types/node@22.19.13':
+    resolution: {integrity: sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -1390,8 +1393,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@7.18.2:
-    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -1792,11 +1795,11 @@ snapshots:
 
   '@types/better-sqlite3@7.6.13':
     dependencies:
-      '@types/node': 25.3.3
+      '@types/node': 22.19.13
 
-  '@types/node@25.3.3':
+  '@types/node@22.19.13':
     dependencies:
-      undici-types: 7.18.2
+      undici-types: 6.21.0
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
@@ -2359,7 +2362,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  undici-types@7.18.2: {}
+  undici-types@6.21.0: {}
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
## Summary
Implements the `@clawops/shared` package — the foundation everything else imports from.

## Changes
- `src/modelPricing.ts` — pricing table for all models + `getModelPricing()` with ollama/* wildcard
- `src/constants.ts` — typed const objects for all status/priority/type enums
- `src/utils.ts` — `generateId()`, `hashApiKey()`, `verifyApiKey()`, `formatCost()`, `calcCost()`
- `src/types.ts` — shared TypeScript interfaces
- `src/index.ts` — re-exports everything
- pnpm typecheck: ✅ 13/13 packages passing

## Review checklist
- [x] pnpm typecheck passes with zero errors
- [x] No `any` types
- [x] node:crypto used for hashing — no external deps
- [x] No dependencies on other @clawops/* packages
- [x] All exports present and typed

Closes #13