### PR TITLE
feat: packages/agents — agent business logic (#14)

### DIFF
--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -10,9 +10,12 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@clawops/core": "workspace:*"
+    "@clawops/core": "workspace:*",
+    "@clawops/domain": "workspace:*",
+    "drizzle-orm": "^0.38.0"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "typescript": "^5.7.0"
   }
 }

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -1,1 +1,171 @@
-export {};
+import { eq, and } from "drizzle-orm";
+import type { DB, Agent } from "@clawops/core";
+import { agents, toJsonArray } from "@clawops/core";
+import { generateId, hashApiKey, type AgentStatus } from "@clawops/domain";
+
+// ── Input types ────────────────────────────────────────────────────────────
+
+interface CreateAgentInput {
+  name: string;
+  model: string;
+  role: string;
+  framework: string;
+  memoryPath?: string;
+  skills?: string[];
+  avatar?: string;
+}
+
+interface InitAgentInput {
+  name: string;
+  model: string;
+  role: string;
+  framework: string;
+  memoryPath?: string;
+  skills?: string[];
+}
+
+// ── createAgent ────────────────────────────────────────────────────────────
+
+export function createAgent(
+  db: DB,
+  input: CreateAgentInput,
+): Agent & { apiKey: string } {
+  const rawKey = generateId();
+  const hashed = hashApiKey(rawKey);
+
+  const rows = db
+    .insert(agents)
+    .values({
+      name: input.name,
+      model: input.model,
+      role: input.role,
+      framework: input.framework,
+      memoryPath: input.memoryPath ?? null,
+      skills: input.skills ? toJsonArray(input.skills) : null,
+      avatar: input.avatar ?? null,
+      apiKey: hashed,
+      status: "offline",
+    })
+    .returning()
+    .all();
+
+  const agent = rows[0]!;
+  return { ...agent, apiKey: rawKey };
+}
+
+// ── getAgent ───────────────────────────────────────────────────────────────
+
+export function getAgent(db: DB, id: string): Agent | null {
+  const rows = db
+    .select()
+    .from(agents)
+    .where(eq(agents.id, id))
+    .limit(1)
+    .all();
+  return rows[0] ?? null;
+}
+
+// ── listAgents ─────────────────────────────────────────────────────────────
+
+export function listAgents(db: DB): Agent[] {
+  return db.select().from(agents).all();
+}
+
+// ── updateAgentStatus ──────────────────────────────────────────────────────
+
+export function updateAgentStatus(
+  db: DB,
+  id: string,
+  status: AgentStatus,
+  _message?: string,
+): Agent {
+  const now = new Date();
+  const rows = db
+    .update(agents)
+    .set({
+      status,
+      lastActive: now,
+    })
+    .where(eq(agents.id, id))
+    .returning()
+    .all();
+
+  const agent = rows[0];
+  if (!agent) {
+    throw new Error(`Agent not found: ${id}`);
+  }
+
+  return agent;
+}
+
+// ── updateAgentSkills ──────────────────────────────────────────────────────
+
+export function updateAgentSkills(
+  db: DB,
+  id: string,
+  skills: string[],
+): Agent {
+  const rows = db
+    .update(agents)
+    .set({ skills: toJsonArray(skills) })
+    .where(eq(agents.id, id))
+    .returning()
+    .all();
+
+  const agent = rows[0];
+  if (!agent) {
+    throw new Error(`Agent not found: ${id}`);
+  }
+
+  return agent;
+}
+
+// ── getAgentByApiKey ───────────────────────────────────────────────────────
+
+export function getAgentByApiKey(db: DB, hashedKey: string): Agent | null {
+  const rows = db
+    .select()
+    .from(agents)
+    .where(eq(agents.apiKey, hashedKey))
+    .limit(1)
+    .all();
+  return rows[0] ?? null;
+}
+
+// ── initAgent ──────────────────────────────────────────────────────────────
+
+export function initAgent(
+  db: DB,
+  input: InitAgentInput,
+): { agent: Agent; apiKey?: string; created: boolean } {
+  const existing = db
+    .select()
+    .from(agents)
+    .where(and(eq(agents.name, input.name), eq(agents.framework, input.framework)))
+    .limit(1)
+    .all();
+
+  if (existing[0]) {
+    return { agent: existing[0], created: false };
+  }
+
+  const rawKey = generateId();
+  const hashed = hashApiKey(rawKey);
+
+  const rows = db
+    .insert(agents)
+    .values({
+      name: input.name,
+      model: input.model,
+      role: input.role,
+      framework: input.framework,
+      memoryPath: input.memoryPath ?? null,
+      skills: input.skills ? toJsonArray(input.skills) : null,
+      apiKey: hashed,
+      status: "offline",
+    })
+    .returning()
+    .all();
+
+  return { agent: rows[0]!, apiKey: rawKey, created: true };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,7 +77,16 @@ importers:
       '@clawops/core':
         specifier: workspace:*
         version: link:../core
+      '@clawops/domain':
+        specifier: workspace:*
+        version: link:../domain
+      drizzle-orm:
+        specifier: ^0.38.0
+        version: 0.38.4(@types/better-sqlite3@7.6.13)(@types/react@19.2.14)(better-sqlite3@11.10.0)(react@19.2.4)
     devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.13
       typescript:
         specifier: ^5.7.0
         version: 5.9.3


### PR DESCRIPTION
## Summary
Implements all agent business logic in `packages/agents`.

## Functions
- `createAgent()` — creates agent, hashes API key, never returns raw key except on creation
- `getAgent()` / `listAgents()`
- `updateAgentStatus()` — updates status + lastActive
- `updateAgentSkills()`
- `getAgentByApiKey()` — lookup by hashed key
- `initAgent()` — idempotent upsert by name+framework

## Checklist
- [x] pnpm typecheck: ✅ 14/14 passing
- [x] No `any` types
- [x] All functions have explicit return types
- [x] API keys never returned in plaintext
- [x] Drizzle ORM only, no raw SQL
- [x] Imports from @clawops/domain (not @clawops/shared)

Closes #14