### PR TITLE
feat: packages/projects — project and milestone logic (#16)

### DIFF
--- a/packages/projects/package.json
+++ b/packages/projects/package.json
@@ -10,9 +10,12 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@clawops/core": "workspace:*"
+    "@clawops/core": "workspace:*",
+    "@clawops/domain": "workspace:*",
+    "drizzle-orm": "^0.38.0"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "typescript": "^5.7.0"
   }
 }

--- a/packages/projects/src/index.ts
+++ b/packages/projects/src/index.ts
@@ -1,1 +1,165 @@
-export {};
+import { eq, and, count } from "drizzle-orm";
+import type { DB } from "@clawops/core";
+import {
+  projects,
+  milestones,
+  tasks,
+  type Project,
+  type Milestone,
+} from "@clawops/core";
+import type { ProjectStatus, MilestoneStatus } from "@clawops/domain";
+
+// ── Projects ─────────────────────────────────────────────────────────────────
+
+export function createProject(
+  db: DB,
+  input: { name: string; description?: string; status?: ProjectStatus; prd?: string },
+): Project {
+  const project = db
+    .insert(projects)
+    .values({
+      name: input.name,
+      description: input.description ?? null,
+      status: input.status ?? "planning",
+      prd: input.prd ?? null,
+      prdUpdatedAt: input.prd ? new Date() : null,
+    })
+    .returning()
+    .get();
+  return project;
+}
+
+export function getProject(
+  db: DB,
+  id: string,
+): (Project & { milestones: Milestone[]; taskCount: number }) | null {
+  const project = db.select().from(projects).where(eq(projects.id, id)).get();
+  if (!project) return null;
+
+  const projectMilestones = db
+    .select()
+    .from(milestones)
+    .where(eq(milestones.projectId, id))
+    .orderBy(milestones.order)
+    .all();
+
+  const taskCountResult = db
+    .select({ count: count() })
+    .from(tasks)
+    .where(eq(tasks.projectId, id))
+    .get();
+
+  return {
+    ...project,
+    milestones: projectMilestones,
+    taskCount: taskCountResult?.count ?? 0,
+  };
+}
+
+export function listProjects(db: DB): Project[] {
+  return db.select().from(projects).all();
+}
+
+export function updateProject(
+  db: DB,
+  id: string,
+  updates: Partial<{ name: string; description: string; status: ProjectStatus; prd: string }>,
+): Project {
+  const values: Record<string, unknown> = { ...updates };
+  if (updates.prd !== undefined) {
+    values["prdUpdatedAt"] = new Date();
+  }
+
+  const project = db
+    .update(projects)
+    .set(values)
+    .where(eq(projects.id, id))
+    .returning()
+    .get();
+  return project;
+}
+
+// ── Milestones ───────────────────────────────────────────────────────────────
+
+export function createMilestone(
+  db: DB,
+  projectId: string,
+  input: { title: string; order?: number },
+): Milestone {
+  const order =
+    input.order ??
+    (db
+      .select({ count: count() })
+      .from(milestones)
+      .where(eq(milestones.projectId, projectId))
+      .get()?.count ?? 0);
+
+  const milestone = db
+    .insert(milestones)
+    .values({
+      projectId,
+      title: input.title,
+      order,
+    })
+    .returning()
+    .get();
+  return milestone;
+}
+
+export function updateMilestone(
+  db: DB,
+  id: string,
+  updates: Partial<{ title: string; status: MilestoneStatus; order: number }>,
+): Milestone {
+  const milestone = db
+    .update(milestones)
+    .set(updates)
+    .where(eq(milestones.id, id))
+    .returning()
+    .get();
+  return milestone;
+}
+
+export function reorderMilestones(
+  db: DB,
+  projectId: string,
+  orderedIds: string[],
+): Milestone[] {
+  const results: Milestone[] = [];
+  for (let i = 0; i < orderedIds.length; i++) {
+    const milestone = db
+      .update(milestones)
+      .set({ order: i })
+      .where(eq(milestones.id, orderedIds[i]))
+      .returning()
+      .get();
+    results.push(milestone);
+  }
+  return results;
+}
+
+// ── Progress ─────────────────────────────────────────────────────────────────
+
+export function getProjectProgress(
+  db: DB,
+  id: string,
+): { total: number; completed: number; percent: number } {
+  const totalResult = db
+    .select({ count: count() })
+    .from(tasks)
+    .where(eq(tasks.projectId, id))
+    .get();
+
+  const total = totalResult?.count ?? 0;
+
+  const completedResult = db
+    .select({ count: count() })
+    .from(tasks)
+    .where(and(eq(tasks.projectId, id), eq(tasks.status, "done")))
+    .get();
+
+  const completed = completedResult?.count ?? 0;
+  const percent = total === 0 ? 0 : Math.round((completed / total) * 100);
+
+  return { total, completed, percent };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,7 +155,16 @@ importers:
       '@clawops/core':
         specifier: workspace:*
         version: link:../core
+      '@clawops/domain':
+        specifier: workspace:*
+        version: link:../domain
+      drizzle-orm:
+        specifier: ^0.38.0
+        version: 0.38.4(@types/better-sqlite3@7.6.13)(@types/react@19.2.14)(better-sqlite3@11.10.0)(react@19.2.4)
     devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.13
       typescript:
         specifier: ^5.7.0
         version: 5.9.3


### PR DESCRIPTION
## Summary
Implements all project and milestone business logic in `packages/projects`.

## Functions
- `createProject()`, `getProject()` (includes milestones + taskCount), `listProjects()`, `updateProject()`
- `createMilestone()`, `updateMilestone()`, `reorderMilestones()`
- `getProjectProgress()` — returns { total, completed, percent }

## Checklist
- [x] pnpm typecheck: ✅ 14/14 passing
- [x] No `any` types
- [x] All functions have explicit return types
- [x] Drizzle ORM only, no raw SQL

Closes #16