### PR TITLE
feat: packages/ideas — idea business logic (#17)

### DIFF
--- a/packages/ideas/package.json
+++ b/packages/ideas/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "@clawops/core": "workspace:*",
     "@clawops/domain": "workspace:*",
-    "@clawops/projects": "workspace:*",
     "drizzle-orm": "^0.38.0"
   },
   "devDependencies": {

--- a/packages/ideas/src/index.ts
+++ b/packages/ideas/src/index.ts
@@ -1,13 +1,13 @@
 import { eq } from "drizzle-orm";
-import type { DB, Idea, Project } from "@clawops/core";
-import { ideas, parseJsonArray, toJsonArray } from "@clawops/core";
-import { createProject } from "@clawops/projects";
+import type { DB, Idea, NewIdea, Project } from "@clawops/core";
+import { ideas, projects, parseJsonArray, toJsonArray } from "@clawops/core";
+import type { IdeaStatus } from "@clawops/domain";
 
-export async function createIdea(
+export function createIdea(
   db: DB,
-  input: { title: string; description?: string; tags?: string[]; source?: "human" | "agent" },
-): Promise<Idea> {
-  const [idea] = await db
+  input: { title: string; description?: string; tags?: string[]; source?: NewIdea["source"] },
+): Idea {
+  const [idea] = db
     .insert(ideas)
     .values({
       title: input.title,
@@ -15,23 +15,25 @@ export async function createIdea(
       tags: input.tags ? toJsonArray(input.tags) : null,
       source: input.source ?? "human",
     })
-    .returning();
+    .returning()
+    .all();
   return idea;
 }
 
-export async function listIdeas(
+export function listIdeas(
   db: DB,
-  filters?: { status?: "raw" | "reviewed" | "promoted" | "archived"; tag?: string },
-): Promise<Idea[]> {
+  filters?: { status?: IdeaStatus; tag?: string },
+): Idea[] {
   let result: Idea[];
 
   if (filters?.status) {
-    result = await db
+    result = db
       .select()
       .from(ideas)
-      .where(eq(ideas.status, filters.status));
+      .where(eq(ideas.status, filters.status))
+      .all();
   } else {
-    result = await db.select().from(ideas);
+    result = db.select().from(ideas).all();
   }
 
   if (filters?.tag) {
@@ -42,54 +44,72 @@ export async function listIdeas(
   return result;
 }
 
-export async function updateIdea(
+export function updateIdea(
   db: DB,
   id: string,
   updates: Partial<{
     title: string;
     description: string;
-    status: "raw" | "reviewed" | "promoted" | "archived";
+    status: IdeaStatus;
     tags: string[];
   }>,
-): Promise<Idea> {
+): Idea {
   const values: Record<string, unknown> = {};
   if (updates.title !== undefined) values["title"] = updates.title;
   if (updates.description !== undefined) values["description"] = updates.description;
   if (updates.status !== undefined) values["status"] = updates.status;
   if (updates.tags !== undefined) values["tags"] = toJsonArray(updates.tags);
 
-  const [idea] = await db
+  const [idea] = db
     .update(ideas)
     .set(values)
     .where(eq(ideas.id, id))
-    .returning();
+    .returning()
+    .all();
   return idea;
 }
 
-export async function promoteIdeaToProject(
+export function promoteIdeaToProject(
   db: DB,
   ideaId: string,
-): Promise<{ idea: Idea; project: Project }> {
-  const [existing] = await db
+): { idea: Idea; project: Project } {
+  const [existing] = db
     .select()
     .from(ideas)
-    .where(eq(ideas.id, ideaId));
+    .where(eq(ideas.id, ideaId))
+    .all();
 
   if (!existing) {
     throw new Error(`Idea not found: ${ideaId}`);
   }
 
-  const project = await createProject(db, {
-    name: existing.title,
-    description: existing.description ?? undefined,
-    ideaId: existing.id,
+  if (existing.status === "promoted" || existing.projectId) {
+    throw new Error(`Idea "${ideaId}" is already promoted`);
+  }
+
+  const tags = parseJsonArray(existing.tags);
+  const description = tags.length > 0
+    ? `${existing.description ?? ""}\n\nTags: ${tags.join(", ")}`.trim()
+    : existing.description ?? undefined;
+
+  return db.transaction((tx) => {
+    const [project] = tx
+      .insert(projects)
+      .values({
+        name: existing.title,
+        description: description ?? null,
+        ideaId: existing.id,
+      })
+      .returning()
+      .all();
+
+    const [idea] = tx
+      .update(ideas)
+      .set({ status: "promoted", projectId: project.id })
+      .where(eq(ideas.id, ideaId))
+      .returning()
+      .all();
+
+    return { idea, project };
   });
-
-  const [idea] = await db
-    .update(ideas)
-    .set({ status: "promoted", projectId: project.id })
-    .where(eq(ideas.id, ideaId))
-    .returning();
-
-  return { idea, project };
 }

--- a/packages/projects/src/index.ts
+++ b/packages/projects/src/index.ts
@@ -9,11 +9,11 @@ import {
 } from "@clawops/core";
 import type { ProjectStatus, MilestoneStatus } from "@clawops/domain";
 
-export async function createProject(
+export function createProject(
   db: DB,
   input: { name: string; description?: string; status?: ProjectStatus; prd?: string; ideaId?: string },
-): Promise<Project> {
-  const project = await db
+): Project {
+  const project = db
     .insert(projects)
     .values({
       name: input.name,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,9 +147,6 @@ importers:
       '@clawops/domain':
         specifier: workspace:*
         version: link:../domain
-      '@clawops/projects':
-        specifier: workspace:*
-        version: link:../projects
       drizzle-orm:
         specifier: ^0.38.0
         version: 0.38.4(@types/better-sqlite3@7.6.13)(@types/react@19.2.14)(better-sqlite3@11.10.0)(react@19.2.4)


### PR DESCRIPTION
## Summary
Implements all idea business logic in `packages/ideas`.

## Functions
- `createIdea()`, `listIdeas()` (with status/tag filters), `updateIdea()`
- `promoteIdeaToProject()` — creates project from idea, sets idea.projectId + status='promoted'

## Checklist
- [x] pnpm typecheck: ✅ 15/15 passing
- [x] No `any` types, explicit return types
- [x] Drizzle ORM only, no raw SQL
- [x] promoteIdeaToProject returns both updated idea and new project

Closes #17