### PR TITLE
feat: packages/notifications — notification logic (#19)

### DIFF
--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -10,9 +10,12 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@clawops/core": "workspace:*"
+    "@clawops/core": "workspace:*",
+    "@clawops/domain": "workspace:*"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
+    "drizzle-orm": "^0.38.0",
     "typescript": "^5.7.0"
   }
 }

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -1,1 +1,77 @@
-export {};
+import { eq, desc, count } from "drizzle-orm";
+import type { DB, Notification } from "@clawops/core";
+import { notifications } from "@clawops/core";
+import { generateId } from "@clawops/domain";
+
+interface CreateNotificationInput {
+  type: string;
+  title: string;
+  body: string;
+  entityType: string;
+  entityId: string;
+}
+
+interface ListNotificationFilters {
+  read?: boolean;
+}
+
+export function createNotification(
+  db: DB,
+  input: CreateNotificationInput,
+): Notification {
+  const [notification] = db
+    .insert(notifications)
+    .values({
+      id: generateId(),
+      type: input.type,
+      title: input.title,
+      body: input.body,
+      entityType: input.entityType,
+      entityId: input.entityId,
+    })
+    .returning()
+    .all();
+  return notification;
+}
+
+export function listNotifications(
+  db: DB,
+  filters?: ListNotificationFilters,
+): Notification[] {
+  const query = db.select().from(notifications);
+
+  if (filters?.read !== undefined) {
+    return query
+      .where(eq(notifications.read, filters.read))
+      .orderBy(desc(notifications.createdAt))
+      .all();
+  }
+
+  return query.orderBy(desc(notifications.createdAt)).all();
+}
+
+export function markRead(db: DB, id: string): Notification {
+  const [notification] = db
+    .update(notifications)
+    .set({ read: true })
+    .where(eq(notifications.id, id))
+    .returning()
+    .all();
+  return notification;
+}
+
+export function markAllRead(db: DB): void {
+  db.update(notifications)
+    .set({ read: true })
+    .where(eq(notifications.read, false))
+    .run();
+}
+
+export function getUnreadCount(db: DB): number {
+  const [result] = db
+    .select({ value: count() })
+    .from(notifications)
+    .where(eq(notifications.read, false))
+    .all();
+  return result.value;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,7 +145,16 @@ importers:
       '@clawops/core':
         specifier: workspace:*
         version: link:../core
+      '@clawops/domain':
+        specifier: workspace:*
+        version: link:../domain
     devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.13
+      drizzle-orm:
+        specifier: ^0.38.0
+        version: 0.38.4(@types/better-sqlite3@7.6.13)(@types/react@19.2.14)(better-sqlite3@11.10.0)(react@19.2.4)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3


### PR DESCRIPTION
## Summary
Implements all notification logic in `packages/notifications`.

## Functions
- `createNotification()`, `listNotifications()` (most recent first, filterable by read)
- `markRead()`, `markAllRead()`, `getUnreadCount()`

## Checklist
- [x] pnpm typecheck: ✅ 14/14 passing
- [x] No `any` types, explicit return types
- [x] Drizzle ORM only, no raw SQL

Closes #19