### PR TITLE
fix(cli): change dev script to tsc --watch

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "dev": "node --import tsx src/index.ts",
+    "dev": "tsc --watch",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/",
     "clean": "rm -rf dist",


### PR DESCRIPTION
## Problem
`pnpm dev` was crashing immediately because `@clawops/cli`'s dev script runs the CLI binary with no arguments — it prints help and exits with code 1, which kills the entire Turbo dev session.

## Fix
Change the CLI `dev` script from:
```
node --import tsx src/index.ts
```
To:
```
tsc --watch
```

The CLI is not a server — it doesn't need a long-running process. `tsc --watch` rebuilds the dist on source changes and stays alive in the pipeline.

## Checks
- [x] `pnpm dev` no longer crashes
- [x] CLI still works: `node apps/cli/dist/index.js --help`