### PR TITLE
fix(core): remove duplicate agent_sessions migrations blocking integration tests

### DIFF
--- a/packages/core/migrations/0002_broken_sprite.sql
+++ b/packages/core/migrations/0002_broken_sprite.sql
@@ -1,16 +1,3 @@
-CREATE TABLE `agent_sessions` (
-	`id` text PRIMARY KEY NOT NULL,
-	`agent_id` text NOT NULL,
-	`project_id` text,
-	`status` text DEFAULT 'inactive' NOT NULL,
-	`last_session_summary` text,
-	`started_at` integer DEFAULT (unixepoch()) NOT NULL,
-	`ended_at` integer,
-	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
-	FOREIGN KEY (`agent_id`) REFERENCES `agents`(`id`) ON UPDATE no action ON DELETE no action,
-	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE no action
-);
---> statement-breakpoint
 ALTER TABLE `projects` ADD `spec_content` text;--> statement-breakpoint
 ALTER TABLE `projects` ADD `spec_updated_at` integer;--> statement-breakpoint
 ALTER TABLE `tasks` ADD `spec_content` text;--> statement-breakpoint


### PR DESCRIPTION
## Summary

This PR resolves the duplicate migration issue blocking package-level integration tests.

## Problem

The core migration set contained two migrations that both create the `agent_sessions` table:
- `packages/core/migrations/0001_lazy_project_context.sql`
- `packages/core/migrations/0002_broken_sprite.sql`

This caused duplicate DDL errors when applying migrations to a fresh database.

## Solution

1. **Deleted** `0001_lazy_project_context.sql` (only contained duplicate CREATE TABLE)
2. **Removed** duplicate CREATE TABLE from `0002_broken_sprite.sql`, kept ALTER TABLE statements for `spec_content` columns
3. **Updated** migration journal to reference the correct migration file (`0001_crimson_silver_surfer`)
4. **Created** missing `0001_snapshot.json` for migration tracking
5. **Generated** `0003_damp_fabian_cortez.sql` for pending schema additions (task_templates, task_template_stages, ideas.sections)

## Verification

- ✅ Fresh database can run the full migration set without duplicate table errors
- ✅ Final schema matches current core expectations
- ✅ Package integration tests pass with the real migration set
- ✅ `pnpm typecheck`, `pnpm test`, and `pnpm lint` complete without new errors

Closes #150