### PR TITLE
fix(web): remove dead top-level navigation routes and align sidebar with roadmap

### DIFF
--- a/apps/web/components/sidebar.tsx
+++ b/apps/web/components/sidebar.tsx
@@ -4,28 +4,24 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
   LayoutDashboard,
-  FolderKanban,
   CheckSquare,
   Lightbulb,
+  FolderKanban,
   BarChart3,
   Bell,
   Settings,
-  Cog,
   User,
-  BookOpen,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const navItems = [
-  { href: "/", label: "Fleet", icon: LayoutDashboard },
-  { href: "/projects", label: "Projects", icon: FolderKanban },
+  { href: "/", label: "Overview", icon: LayoutDashboard },
   { href: "/tasks", label: "Tasks", icon: CheckSquare },
   { href: "/ideas", label: "Ideas", icon: Lightbulb },
+  { href: "/projects", label: "Projects", icon: FolderKanban },
   { href: "/analytics", label: "Analytics", icon: BarChart3 },
   { href: "/notifications", label: "Notifications", icon: Bell },
   { href: "/settings", label: "Settings", icon: Settings },
-  { href: "/config", label: "Config", icon: Cog },
-  { href: "/docs/api", label: "API Docs", icon: BookOpen },
 ] as const;
 
 export function Sidebar(): React.JSX.Element {


### PR DESCRIPTION
closes #105

## Summary
- remove the dead `/config` sidebar route
- remove non-primary `API Docs` from the main sidebar so primary nav only includes real app sections
- rename `Fleet` to `Overview` to match the current home page and roadmap terminology

## Files Changed
- `apps/web/components/sidebar.tsx`

## Validation Results
- `pnpm lint` ✅
- `pnpm typecheck` ✅
- `pnpm test` ✅
- `pnpm build` ✅