### PR TITLE
fix: eliminate tx as unknown as DB — export DBOrTx union from @clawops/core

### DIFF
--- a/apps/cli/src/lib/client.ts
+++ b/apps/cli/src/lib/client.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console -- CLI tool uses console for output */
 import type {
   DB,
+  DBOrTx,
   Task,
   Idea,
   Project,
@@ -75,7 +76,7 @@ function getDb(): DB {
   return coreDb;
 }
 
-function logReadEvent(db: DB, entityType: string, entityId: string): void {
+function logReadEvent(db: DBOrTx, entityType: string, entityId: string): void {
   db.insert(events)
     .values({ action: "read", entityType, entityId })
     .run();

--- a/apps/web/app/api/agents/[id]/heartbeat/route.ts
+++ b/apps/web/app/api/agents/[id]/heartbeat/route.ts
@@ -1,7 +1,7 @@
 export const dynamic = "force-dynamic";
 
 import crypto from "node:crypto";
-import { events, type DB } from "@clawops/core";
+import { events } from "@clawops/core";
 import { getAgent, updateAgentStatus } from "@clawops/agents";
 import { logHeartbeat } from "@clawops/habits";
 import { AgentStatus } from "@clawops/domain";
@@ -27,8 +27,8 @@ export async function POST(
   }
 
   const run = db.transaction((tx) => {
-    const r = logHeartbeat(tx as unknown as DB, id);
-    updateAgentStatus(tx as unknown as DB, id, AgentStatus.online);
+    const r = logHeartbeat(tx, id);
+    updateAgentStatus(tx, id, AgentStatus.online);
     tx.insert(events)
       .values({
         id: crypto.randomUUID(),

--- a/apps/web/app/api/agents/[id]/skills/route.ts
+++ b/apps/web/app/api/agents/[id]/skills/route.ts
@@ -1,7 +1,7 @@
 export const dynamic = "force-dynamic";
 
 import crypto from "node:crypto";
-import { events, type DB } from "@clawops/core";
+import { events } from "@clawops/core";
 import { updateAgentSkills } from "@clawops/agents";
 import { NextResponse } from "next/server";
 import { z } from "zod";
@@ -25,7 +25,7 @@ export async function PATCH(
     const body = skillsSchema.parse(await req.json());
     const db = getDb();
     const agent = db.transaction((tx) => {
-      const a = updateAgentSkills(tx as unknown as DB, id, body.skills);
+      const a = updateAgentSkills(tx, id, body.skills);
       tx.insert(events)
         .values({
           id: crypto.randomUUID(),

--- a/apps/web/app/api/agents/[id]/status/route.ts
+++ b/apps/web/app/api/agents/[id]/status/route.ts
@@ -1,7 +1,7 @@
 export const dynamic = "force-dynamic";
 
 import crypto from "node:crypto";
-import { events, type DB } from "@clawops/core";
+import { events } from "@clawops/core";
 import { updateAgentStatus } from "@clawops/agents";
 import { AgentStatus } from "@clawops/domain";
 import { NextResponse } from "next/server";
@@ -29,7 +29,7 @@ export async function PATCH(
     const body = statusSchema.parse(await req.json());
     const db = getDb();
     const agent = db.transaction((tx) => {
-      const a = updateAgentStatus(tx as unknown as DB, id, body.status, body.message);
+      const a = updateAgentStatus(tx, id, body.status, body.message);
       tx.insert(events)
         .values({
           id: crypto.randomUUID(),

--- a/apps/web/app/api/agents/route.ts
+++ b/apps/web/app/api/agents/route.ts
@@ -1,7 +1,7 @@
 export const dynamic = "force-dynamic";
 
 import crypto from "node:crypto";
-import { events, type Agent, type DB } from "@clawops/core";
+import { events, type Agent } from "@clawops/core";
 import { createAgent, listAgents } from "@clawops/agents";
 import { NextResponse } from "next/server";
 import { z } from "zod";
@@ -39,7 +39,7 @@ export async function POST(req: Request): Promise<NextResponse> {
     const data = registerSchema.parse(await req.json());
     const db = getDb();
     const result = db.transaction((tx) => {
-      const agent = createAgent(tx as unknown as DB, data);
+      const agent = createAgent(tx, data);
       tx.insert(events)
         .values({
           id: crypto.randomUUID(),

--- a/apps/web/app/api/habits/[id]/run/route.ts
+++ b/apps/web/app/api/habits/[id]/run/route.ts
@@ -3,7 +3,7 @@ export const dynamic = "force-dynamic";
 import crypto from "node:crypto";
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { events, type DB } from "@clawops/core";
+import { events } from "@clawops/core";
 import { logHabitRun } from "@clawops/habits";
 import { getDb, jsonError, isNotFoundError, requireAgentId } from "@/lib/server/runtime";
 
@@ -25,7 +25,7 @@ export async function POST(
     const body = habitRunSchema.parse(await req.json());
     const db = getDb();
     const run = db.transaction((tx) => {
-      const r = logHabitRun(tx as unknown as DB, id, auth, body);
+      const r = logHabitRun(tx, id, auth, body);
       tx.insert(events)
         .values({
           id: crypto.randomUUID(),

--- a/apps/web/app/api/habits/route.ts
+++ b/apps/web/app/api/habits/route.ts
@@ -3,7 +3,7 @@ export const dynamic = "force-dynamic";
 import crypto from "node:crypto";
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { events, type DB } from "@clawops/core";
+import { events } from "@clawops/core";
 import { getAgent } from "@clawops/agents";
 import { createHabit, listHabits } from "@clawops/habits";
 import { HabitStatus, HabitType } from "@clawops/domain";
@@ -42,7 +42,7 @@ export async function POST(req: Request): Promise<NextResponse> {
     if (!agent) return jsonError(404, "Agent not found", "NOT_FOUND");
 
     const habit = db.transaction((tx) => {
-      const h = createHabit(tx as unknown as DB, auth, body);
+      const h = createHabit(tx, auth, body);
       tx.insert(events)
         .values({
           id: crypto.randomUUID(),

--- a/apps/web/app/api/ideas/[id]/draft-prd/route.ts
+++ b/apps/web/app/api/ideas/[id]/draft-prd/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
-import { events, type DB } from "@clawops/core";
+import { events } from "@clawops/core";
 import { getIdeaDraftPrd, setIdeaDraftPrd } from "@clawops/ideas";
 import { NotFoundError } from "@clawops/domain";
 import { getDb, jsonError, requireAgentId } from "@/lib/server/runtime";
@@ -43,7 +43,7 @@ export async function PUT(
     const db = getDb();
 
     const idea = db.transaction((tx) => {
-      const result = setIdeaDraftPrd(tx as unknown as DB, id, body.content);
+      const result = setIdeaDraftPrd(tx, id, body.content);
       tx.insert(events)
         .values({
           action: "idea.draft_prd_updated",

--- a/apps/web/app/api/ideas/[id]/promote/route.ts
+++ b/apps/web/app/api/ideas/[id]/promote/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
-import { events, createActivityEvent, type DB } from "@clawops/core";
+import { events, createActivityEvent } from "@clawops/core";
 import { promoteIdeaToProject } from "@clawops/ideas";
 import { ConflictError, NotFoundError } from "@clawops/domain";
 import { getDb, jsonError, requireAgentId } from "@/lib/server/runtime";
@@ -18,7 +18,7 @@ export async function POST(
   const db = getDb();
   try {
     const result = db.transaction((tx) => {
-      const r = promoteIdeaToProject(tx as unknown as DB, id);
+      const r = promoteIdeaToProject(tx, id);
       tx.insert(events)
         .values({
           action: "idea.promoted",
@@ -37,7 +37,7 @@ export async function POST(
           meta: JSON.stringify({ name: r.project.name, ideaId: r.idea.id }),
         })
         .run();
-      createActivityEvent(tx as unknown as DB, {
+      createActivityEvent(tx, {
         source: "agent",
         type: "idea.promoted",
         title: `Idea promoted to project: ${r.idea.title}`,
@@ -47,7 +47,7 @@ export async function POST(
         agentId,
         metadata: JSON.stringify({ ideaTitle: r.idea.title, projectId: r.project.id, projectName: r.project.name }),
       });
-      createActivityEvent(tx as unknown as DB, {
+      createActivityEvent(tx, {
         source: "agent",
         type: "project.created",
         title: `Project created from idea: ${r.project.name}`,

--- a/apps/web/app/api/ideas/[id]/sections/[section]/route.ts
+++ b/apps/web/app/api/ideas/[id]/sections/[section]/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
-import { events, type DB } from "@clawops/core";
+import { events } from "@clawops/core";
 import { getIdeaSection, IDEA_SECTION_KEYS, updateIdeaSection, type IdeaSectionKey } from "@clawops/ideas";
 import { NotFoundError } from "@clawops/domain";
 import { getDb, jsonError } from "@/lib/server/runtime";
@@ -42,7 +42,7 @@ export async function PUT(
     const db = getDb();
 
     const idea = db.transaction((tx) => {
-      const result = updateIdeaSection(tx as unknown as DB, id, sectionKey, body.content);
+      const result = updateIdeaSection(tx, id, sectionKey, body.content);
       tx.insert(events)
         .values({
           action: "idea.section_updated",

--- a/apps/web/app/api/ideas/[id]/sections/route.ts
+++ b/apps/web/app/api/ideas/[id]/sections/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
-import { events, createActivityEvent, type DB } from "@clawops/core";
+import { events, createActivityEvent } from "@clawops/core";
 import { getIdeaSections, updateIdeaSections } from "@clawops/ideas";
 import { NotFoundError } from "@clawops/domain";
 import { getDb, jsonError, requireAgentId } from "@/lib/server/runtime";
@@ -51,7 +51,7 @@ export async function PATCH(
     const db = getDb();
 
     const idea = db.transaction((tx) => {
-      const result = updateIdeaSections(tx as unknown as DB, id, body.sections);
+      const result = updateIdeaSections(tx, id, body.sections);
       tx.insert(events)
         .values({
           action: "idea.sections_updated",
@@ -62,7 +62,7 @@ export async function PATCH(
         })
         .run();
       try {
-        createActivityEvent(tx as unknown as DB, {
+        createActivityEvent(tx, {
           source: "agent",
           type: "idea.updated",
           title: `Idea sections updated: ${result.title}`,

--- a/apps/web/app/api/ideas/[id]/tasks/route.ts
+++ b/apps/web/app/api/ideas/[id]/tasks/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { events, createActivityEvent, type DB } from "@clawops/core";
+import { events, createActivityEvent } from "@clawops/core";
 import { TaskPriority, Source } from "@clawops/domain";
 import { listIdeaTasks, createIdeaTask } from "@clawops/ideas";
 import { getDb, jsonError, parseSearch, requireAgentId } from "@/lib/server/runtime";
@@ -50,7 +50,7 @@ export async function POST(req: Request, { params }: RouteParams): Promise<NextR
     const body = createTaskBody.parse(await req.json());
     const db = getDb();
     const task = db.transaction((tx) => {
-      const t = createIdeaTask(tx as unknown as DB, ideaId, {
+      const t = createIdeaTask(tx, ideaId, {
         title: body.title,
         description: body.description,
         priority: body.priority,
@@ -67,7 +67,7 @@ export async function POST(req: Request, { params }: RouteParams): Promise<NextR
           meta: JSON.stringify({ title: t.title, ideaId }),
         })
         .run();
-      createActivityEvent(tx as unknown as DB, {
+      createActivityEvent(tx, {
         source: "agent",
         type: "task.created",
         title: `Task created: ${t.title}`,

--- a/apps/web/app/api/ideas/route.ts
+++ b/apps/web/app/api/ideas/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { events, createActivityEvent, type DB } from "@clawops/core";
+import { events, createActivityEvent } from "@clawops/core";
 import { ConflictError, IdeaStatus, NotFoundError, Source } from "@clawops/domain";
 import { createIdea, listIdeas } from "@clawops/ideas";
 import { getDb, jsonError, parseSearch, requireAgentId } from "@/lib/server/runtime";
@@ -49,7 +49,7 @@ export async function POST(req: Request): Promise<NextResponse> {
     const body = createIdeaBody.parse(await req.json());
     const db = getDb();
     const idea = db.transaction((tx) => {
-      const i = createIdea(tx as unknown as DB, body);
+      const i = createIdea(tx, body);
       tx.insert(events)
         .values({
           action: "idea.created",
@@ -59,7 +59,7 @@ export async function POST(req: Request): Promise<NextResponse> {
           meta: JSON.stringify({ title: i.title }),
         })
         .run();
-      createActivityEvent(tx as unknown as DB, {
+      createActivityEvent(tx, {
         source: "agent",
         type: "idea.created",
         title: `Idea created: ${i.title}`,

--- a/apps/web/app/api/integrations/openclaw/[id]/route.ts
+++ b/apps/web/app/api/integrations/openclaw/[id]/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { events, type DB } from "@clawops/core";
+import { events } from "@clawops/core";
 import {
   getOpenClawConnection,
   updateOpenClawConnection,
@@ -71,7 +71,7 @@ export async function PATCH(
     const db = getDb();
 
     const updated = db.transaction((tx) => {
-      const connection = updateOpenClawConnection(tx as unknown as DB, id, {
+      const connection = updateOpenClawConnection(tx, id, {
         name: body.name,
         gatewayUrl: body.gatewayUrl,
         status: body.status,

--- a/apps/web/app/api/integrations/openclaw/actions/files/revert/route.ts
+++ b/apps/web/app/api/integrations/openclaw/actions/files/revert/route.ts
@@ -3,7 +3,7 @@ export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { revertTrackedOpenClawFile, OpenClawActionError } from "@clawops/sync/openclaw";
-import { events, createActivityEvent, type DB } from "@clawops/core";
+import { events, createActivityEvent } from "@clawops/core";
 import { getDb, jsonError, requireAgentId } from "@/lib/server/runtime";
 
 const revertFileBodySchema = z.object({
@@ -49,7 +49,7 @@ export async function POST(req: Request): Promise<NextResponse> {
         })
         .run();
 
-      createActivityEvent(tx as unknown as DB, {
+      createActivityEvent(tx, {
         source: "agent",
         severity: "info",
         type: "file.reverted",

--- a/apps/web/app/api/integrations/openclaw/route.ts
+++ b/apps/web/app/api/integrations/openclaw/route.ts
@@ -3,7 +3,7 @@ export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import path from "node:path";
 import { z } from "zod";
-import { events, type DB } from "@clawops/core";
+import { events } from "@clawops/core";
 import {
   listOpenClawConnections,
   upsertOpenClawConnection,
@@ -63,7 +63,7 @@ export async function POST(req: Request): Promise<NextResponse> {
     const body = upsertConnectionBody.parse(await req.json());
     const db = getDb();
     const result = db.transaction((tx) => {
-      const upserted = upsertOpenClawConnection(tx as unknown as DB, {
+      const upserted = upsertOpenClawConnection(tx, {
         name: body.name ?? defaultConnectionName(body.rootPath),
         rootPath: body.rootPath,
         gatewayUrl: body.gatewayUrl,

--- a/apps/web/app/api/notifications/[id]/route.ts
+++ b/apps/web/app/api/notifications/[id]/route.ts
@@ -1,7 +1,7 @@
 export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
-import { events, type DB } from "@clawops/core";
+import { events } from "@clawops/core";
 import { markRead } from "@clawops/notifications";
 import { getAgentIdFromApiKey, getDb, jsonError } from "@/lib/server/runtime";
 
@@ -14,7 +14,7 @@ export async function PATCH(
   const agentId = getAgentIdFromApiKey(_request) ?? undefined;
 
   const notification = db.transaction((tx) => {
-    const n = markRead(tx as unknown as DB, id);
+    const n = markRead(tx, id);
     if (!n) return null;
     tx.insert(events)
       .values({

--- a/apps/web/app/api/notifications/read-all/route.ts
+++ b/apps/web/app/api/notifications/read-all/route.ts
@@ -1,7 +1,7 @@
 export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
-import { events, type DB } from "@clawops/core";
+import { events } from "@clawops/core";
 import { markAllRead } from "@clawops/notifications";
 import { getAgentIdFromApiKey, getDb } from "@/lib/server/runtime";
 
@@ -9,7 +9,7 @@ export async function PATCH(req: Request): Promise<NextResponse> {
   const db = getDb();
   const agentId = getAgentIdFromApiKey(req) ?? undefined;
   db.transaction((tx) => {
-    markAllRead(tx as unknown as DB);
+    markAllRead(tx);
     tx.insert(events)
       .values({
         action: "notification.read-all",

--- a/apps/web/app/api/openclaw/cron-jobs/route.ts
+++ b/apps/web/app/api/openclaw/cron-jobs/route.ts
@@ -3,7 +3,7 @@ export const dynamic = "force-dynamic";
 import crypto from "node:crypto";
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { events, createActivityEvent, type DB } from "@clawops/core";
+import { events, createActivityEvent } from "@clawops/core";
 import {
   listCronJobs,
   syncCronJobs,
@@ -46,7 +46,7 @@ export async function GET(req: Request): Promise<NextResponse> {
       }
 
       // syncCronJobs is async (fetches from gateway) — must run outside the transaction
-      await syncCronJobs(db as DB, connection, getGatewayToken(req));
+      await syncCronJobs(db, connection, getGatewayToken(req));
 
       db.transaction((tx) => {
         tx.insert(events)
@@ -62,7 +62,7 @@ export async function GET(req: Request): Promise<NextResponse> {
           .run();
 
         try {
-          createActivityEvent(tx as unknown as DB, {
+          createActivityEvent(tx, {
             source: "sync",
             type: "cron.synced",
             title: `Cron jobs synced for connection: ${connection.name}`,
@@ -78,7 +78,7 @@ export async function GET(req: Request): Promise<NextResponse> {
     }
 
     return NextResponse.json(
-      listCronJobs(db as DB, connectionId ? { connectionId } : {}),
+      listCronJobs(db, connectionId ? { connectionId } : {}),
     );
   } catch (err) {
     if (err instanceof z.ZodError) {

--- a/apps/web/app/api/projects/[id]/route.ts
+++ b/apps/web/app/api/projects/[id]/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { events, createActivityEvent, type DB } from "@clawops/core";
+import { events, createActivityEvent } from "@clawops/core";
 import { ProjectStatus } from "@clawops/domain";
 import { getProject, updateProject } from "@clawops/projects";
 import { getDb, jsonError, requireAgentId } from "@/lib/server/runtime";
@@ -43,7 +43,7 @@ export async function PATCH(
     if (!existing) return jsonError(404, "Not found", "NOT_FOUND");
 
     const project = db.transaction((tx) => {
-      const p = updateProject(tx as unknown as DB, id, body);
+      const p = updateProject(tx, id, body);
       tx.insert(events)
         .values({
           action: "project.updated",
@@ -53,7 +53,7 @@ export async function PATCH(
           meta: JSON.stringify({ fields: Object.keys(body) }),
         })
         .run();
-      createActivityEvent(tx as unknown as DB, {
+      createActivityEvent(tx, {
         source: "agent",
         type: "project.updated",
         title: `Project updated: ${p.name}`,

--- a/apps/web/app/api/projects/[id]/spec/route.ts
+++ b/apps/web/app/api/projects/[id]/spec/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { events, createActivityEvent, type DB } from "@clawops/core";
+import { events, createActivityEvent } from "@clawops/core";
 import { getProject, getProjectSpec, setProjectSpec, appendProjectSpec } from "@clawops/projects";
 import { getDb, jsonError, requireAgentId } from "@/lib/server/runtime";
 
@@ -56,7 +56,7 @@ export async function PUT(
     if (!project) return jsonError(404, "Project not found", "NOT_FOUND");
 
     const updatedProject = db.transaction((tx) => {
-      const p = setProjectSpec(tx as unknown as DB, id, body.specContent);
+      const p = setProjectSpec(tx, id, body.specContent);
       tx.insert(events)
         .values({
           action: "project.spec_updated",
@@ -66,7 +66,7 @@ export async function PUT(
           meta: JSON.stringify({ specLength: body.specContent.length }),
         })
         .run();
-      createActivityEvent(tx as unknown as DB, {
+      createActivityEvent(tx, {
         source: "agent",
         type: "project.spec_updated",
         title: `Project spec updated: ${project.name}`,
@@ -106,7 +106,7 @@ export async function POST(
     if (!project) return jsonError(404, "Project not found", "NOT_FOUND");
 
     const updatedProject = db.transaction((tx) => {
-      const p = appendProjectSpec(tx as unknown as DB, id, body.content);
+      const p = appendProjectSpec(tx, id, body.content);
       tx.insert(events)
         .values({
           action: "project.spec_appended",
@@ -116,7 +116,7 @@ export async function POST(
           meta: JSON.stringify({ appendedLength: body.content.length }),
         })
         .run();
-      createActivityEvent(tx as unknown as DB, {
+      createActivityEvent(tx, {
         source: "agent",
         type: "project.spec_appended",
         title: `Project spec appended: ${project.name}`,

--- a/apps/web/app/api/projects/route.ts
+++ b/apps/web/app/api/projects/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { events, createActivityEvent, type DB } from "@clawops/core";
+import { events, createActivityEvent } from "@clawops/core";
 import { ProjectStatus } from "@clawops/domain";
 import { createProject, listProjects } from "@clawops/projects";
 import { getDb, jsonError, requireAgentId } from "@/lib/server/runtime";
@@ -30,7 +30,7 @@ export async function POST(req: Request): Promise<NextResponse> {
     const body = createProjectBody.parse(await req.json());
     const db = getDb();
     const project = db.transaction((tx) => {
-      const p = createProject(tx as unknown as DB, body);
+      const p = createProject(tx, body);
       tx.insert(events)
         .values({
           action: "project.created",
@@ -40,7 +40,7 @@ export async function POST(req: Request): Promise<NextResponse> {
           meta: JSON.stringify({ name: p.name }),
         })
         .run();
-      createActivityEvent(tx as unknown as DB, {
+      createActivityEvent(tx, {
         source: "agent",
         type: "project.created",
         title: `Project created: ${p.name}`,

--- a/apps/web/app/api/tasks/[id]/complete/route.ts
+++ b/apps/web/app/api/tasks/[id]/complete/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { events, createActivityEvent, type DB } from "@clawops/core";
+import { events, createActivityEvent } from "@clawops/core";
 import { completeTask } from "@clawops/tasks";
 import { createNotification } from "@clawops/notifications";
 import { getAgentIdFromApiKey, getDb, jsonError } from "@/lib/server/runtime";
@@ -27,9 +27,9 @@ export async function POST(
     const db = getDb();
     const agentId = getAgentIdFromApiKey(req) ?? undefined;
     const task = db.transaction((tx) => {
-      const t = completeTask(tx as unknown as DB, id, body);
+      const t = completeTask(tx, id, body);
       if (!t) return null;
-      createNotification(tx as unknown as DB, {
+      createNotification(tx, {
         type: "task.completed",
         title: "Task completed",
         body: `Task "${t.title}" has been completed.`,
@@ -45,7 +45,7 @@ export async function POST(
           meta: JSON.stringify({ summary: body.summary }),
         })
         .run();
-      createActivityEvent(tx as unknown as DB, {
+      createActivityEvent(tx, {
         source: agentId ? "agent" : "user",
         type: "task.completed",
         title: `Task completed: ${t.title}`,

--- a/apps/web/app/api/tasks/[id]/links/[linkId]/route.ts
+++ b/apps/web/app/api/tasks/[id]/links/[linkId]/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { events, createActivityEvent, type DB } from "@clawops/core";
+import { events, createActivityEvent } from "@clawops/core";
 import { removeTaskResourceLink, getTask } from "@clawops/tasks";
 import { getAgentIdFromApiKey, getDb, jsonError } from "@/lib/server/runtime";
 import { serializeLink } from "../utils";
@@ -23,7 +23,7 @@ export async function DELETE(
     if (!task) return jsonError(404, "Task not found", "TASK_NOT_FOUND");
     const agentId = getAgentIdFromApiKey(req) ?? undefined;
     const removed = db.transaction((tx) => {
-      const link = removeTaskResourceLink(tx as unknown as DB, id, linkId);
+      const link = removeTaskResourceLink(tx, id, linkId);
       if (!link) return null;
       const metadata = {
         linkId: link.id,
@@ -40,7 +40,7 @@ export async function DELETE(
           meta: JSON.stringify(metadata),
         })
         .run();
-      createActivityEvent(tx as unknown as DB, {
+      createActivityEvent(tx, {
         source: agentId ? "agent" : "user",
         type: "task.link.removed",
         title: `Link removed from task: ${task.title}`,

--- a/apps/web/app/api/tasks/[id]/links/route.ts
+++ b/apps/web/app/api/tasks/[id]/links/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { events, createActivityEvent, type DB } from "@clawops/core";
+import { events, createActivityEvent } from "@clawops/core";
 import {
   addTaskResourceLink,
   listTaskResourceLinks,
@@ -51,7 +51,7 @@ export async function POST(
     if (!task) return jsonError(404, "Task not found", "TASK_NOT_FOUND");
     const agentId = getAgentIdFromApiKey(req) ?? undefined;
     const link = db.transaction((tx) => {
-      const created = addTaskResourceLink(tx as unknown as DB, id, body);
+      const created = addTaskResourceLink(tx, id, body);
       const metadata = {
         provider: body.provider,
         resourceType: body.resourceType,
@@ -68,7 +68,7 @@ export async function POST(
           meta: JSON.stringify(metadata),
         })
         .run();
-      createActivityEvent(tx as unknown as DB, {
+      createActivityEvent(tx, {
         source: agentId ? "agent" : "user",
         type: "task.link.added",
         title: `Link added to task: ${task.title}`,

--- a/apps/web/app/api/tasks/[id]/relations/[relationId]/route.ts
+++ b/apps/web/app/api/tasks/[id]/relations/[relationId]/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { events, createActivityEvent, type DB } from "@clawops/core";
+import { events, createActivityEvent } from "@clawops/core";
 import { deleteTaskRelation } from "@clawops/tasks";
 import { getAgentIdFromApiKey, getDb, jsonError } from "@/lib/server/runtime";
 
@@ -17,7 +17,7 @@ export async function DELETE(
     const db = getDb();
     const agentId = getAgentIdFromApiKey(req) ?? undefined;
     db.transaction((tx) => {
-      deleteTaskRelation(tx as unknown as DB, relationId);
+      deleteTaskRelation(tx, relationId);
       tx.insert(events)
         .values({
           action: "task.relation.deleted",
@@ -27,7 +27,7 @@ export async function DELETE(
           meta: JSON.stringify({ relationId }),
         })
         .run();
-      createActivityEvent(tx as unknown as DB, {
+      createActivityEvent(tx, {
         source: agentId ? "agent" : "user",
         type: "task.relation.deleted",
         title: `Task relation deleted`,

--- a/apps/web/app/api/tasks/[id]/relations/route.ts
+++ b/apps/web/app/api/tasks/[id]/relations/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { events, createActivityEvent, type DB } from "@clawops/core";
+import { events, createActivityEvent } from "@clawops/core";
 import { listTaskRelations, createTaskRelation } from "@clawops/tasks";
 import { getAgentIdFromApiKey, getDb, jsonError } from "@/lib/server/runtime";
 
@@ -32,7 +32,7 @@ export async function POST(
     const db = getDb();
     const agentId = getAgentIdFromApiKey(req) ?? undefined;
     const relation = db.transaction((tx) => {
-      const r = createTaskRelation(tx as unknown as DB, {
+      const r = createTaskRelation(tx, {
         fromTaskId: id,
         toTaskId: body.targetTaskId,
         type: body.type,
@@ -46,7 +46,7 @@ export async function POST(
           meta: JSON.stringify({ relationId: r.id, targetTaskId: body.targetTaskId, type: body.type }),
         })
         .run();
-      createActivityEvent(tx as unknown as DB, {
+      createActivityEvent(tx, {
         source: agentId ? "agent" : "user",
         type: "task.relation.created",
         title: `Task relation created: ${body.type}`,

--- a/apps/web/app/api/tasks/[id]/route.ts
+++ b/apps/web/app/api/tasks/[id]/route.ts
@@ -3,7 +3,7 @@ export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { TaskPriority, TaskStatus } from "@clawops/domain";
-import { events, createActivityEvent, type DB } from "@clawops/core";
+import { events, createActivityEvent } from "@clawops/core";
 import { getTask, updateTask } from "@clawops/tasks";
 import { getAgentIdFromApiKey, getDb, jsonError } from "@/lib/server/runtime";
 
@@ -45,7 +45,7 @@ export async function PATCH(
     const db = getDb();
     const agentId = getAgentIdFromApiKey(req) ?? undefined;
     const task = db.transaction((tx) => {
-      const t = updateTask(tx as unknown as DB, id, {
+      const t = updateTask(tx, id, {
         ...body,
         dueDate: body.dueDate ? new Date(body.dueDate) : undefined,
       });
@@ -59,7 +59,7 @@ export async function PATCH(
           meta: JSON.stringify({ fields: Object.keys(body) }),
         })
         .run();
-      createActivityEvent(tx as unknown as DB, {
+      createActivityEvent(tx, {
         source: agentId ? "agent" : "user",
         type: "task.updated",
         title: `Task updated: ${t.title}`,

--- a/apps/web/app/api/tasks/[id]/spec/append/route.ts
+++ b/apps/web/app/api/tasks/[id]/spec/append/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { events, createActivityEvent, type DB } from "@clawops/core";
+import { events, createActivityEvent } from "@clawops/core";
 import { appendTaskSpec } from "@clawops/tasks";
 import { getAgentIdFromApiKey, getDb, jsonError } from "@/lib/server/runtime";
 
@@ -22,7 +22,7 @@ export async function POST(
     const db = getDb();
     const agentId = getAgentIdFromApiKey(req) ?? undefined;
     const task = db.transaction((tx) => {
-      const t = appendTaskSpec(tx as unknown as DB, id, body.content);
+      const t = appendTaskSpec(tx, id, body.content);
       tx.insert(events)
         .values({
           action: "task.spec_appended",
@@ -32,7 +32,7 @@ export async function POST(
           meta: JSON.stringify({ contentLength: body.content.length }),
         })
         .run();
-      createActivityEvent(tx as unknown as DB, {
+      createActivityEvent(tx, {
         source: agentId ? "agent" : "user",
         type: "task.spec_appended",
         title: `Task spec appended: ${t.title}`,

--- a/apps/web/app/api/tasks/[id]/spec/route.ts
+++ b/apps/web/app/api/tasks/[id]/spec/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { eq, events, tasks, createActivityEvent, type DB } from "@clawops/core";
+import { eq, events, tasks, createActivityEvent } from "@clawops/core";
 import { getTaskSpec, setTaskSpec } from "@clawops/tasks";
 import { getAgentIdFromApiKey, getDb, jsonError } from "@/lib/server/runtime";
 
@@ -42,7 +42,7 @@ export async function PUT(
     const db = getDb();
     const agentId = getAgentIdFromApiKey(req) ?? undefined;
     const task = db.transaction((tx) => {
-      const t = setTaskSpec(tx as unknown as DB, id, body.specContent);
+      const t = setTaskSpec(tx, id, body.specContent);
       tx.insert(events)
         .values({
           action: "task.spec_updated",
@@ -52,7 +52,7 @@ export async function PUT(
           meta: JSON.stringify({ specLength: body.specContent.length }),
         })
         .run();
-      createActivityEvent(tx as unknown as DB, {
+      createActivityEvent(tx, {
         source: agentId ? "agent" : "user",
         type: "task.spec_updated",
         title: `Task spec updated: ${t.title}`,

--- a/apps/web/app/api/tasks/route.ts
+++ b/apps/web/app/api/tasks/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { events, createActivityEvent, type DB } from "@clawops/core";
+import { events, createActivityEvent } from "@clawops/core";
 import { TaskPriority, TaskStatus, Source } from "@clawops/domain";
 import { createTask, listTasks } from "@clawops/tasks";
 import { getDb, jsonError, parseSearch, requireAgentId } from "@/lib/server/runtime";
@@ -59,7 +59,7 @@ export async function POST(req: Request): Promise<NextResponse> {
     const body = createTaskBody.parse(await req.json());
     const db = getDb();
     const task = db.transaction((tx) => {
-      const t = createTask(tx as unknown as DB, {
+      const t = createTask(tx, {
         ...body,
         dueDate: body.dueDate ? new Date(body.dueDate) : undefined,
         specContent: body.specContent,
@@ -74,7 +74,7 @@ export async function POST(req: Request): Promise<NextResponse> {
           meta: JSON.stringify({ title: t.title }),
         })
         .run();
-      createActivityEvent(tx as unknown as DB, {
+      createActivityEvent(tx, {
         source: "agent",
         type: "task.created",
         title: `Task created: ${t.title}`,

--- a/apps/web/app/api/workflows/[id]/route.ts
+++ b/apps/web/app/api/workflows/[id]/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { events, createActivityEvent, type DB } from "@clawops/core";
+import { events, createActivityEvent } from "@clawops/core";
 import {
   getWorkflowDefinition,
   updateWorkflowDefinition,
@@ -87,7 +87,7 @@ export async function PATCH(req: Request, { params }: RouteParams): Promise<Next
     }
 
     const workflow = db.transaction((tx) => {
-      const w = updateWorkflowDefinition(tx as unknown as DB, id, {
+      const w = updateWorkflowDefinition(tx, id, {
         name: body.name,
         description: body.description,
         version: body.version,
@@ -106,7 +106,7 @@ export async function PATCH(req: Request, { params }: RouteParams): Promise<Next
           meta: JSON.stringify({ fields: Object.keys(body) }),
         })
         .run();
-      createActivityEvent(tx as unknown as DB, {
+      createActivityEvent(tx, {
         source: "agent",
         type: "workflow.updated",
         title: `Workflow updated: ${w.name}`,

--- a/apps/web/app/api/workflows/[id]/test/route.ts
+++ b/apps/web/app/api/workflows/[id]/test/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { events, createActivityEvent, type DB } from "@clawops/core";
+import { events, createActivityEvent } from "@clawops/core";
 import { createWorkflowRun, getWorkflowDefinition } from "@clawops/workflows";
 import { getDb, jsonError, requireAgentId } from "@/lib/server/runtime";
 
@@ -32,7 +32,7 @@ export async function POST(req: Request, { params }: RouteParams): Promise<NextR
     }
 
     const run = db.transaction((tx) => {
-      const r = createWorkflowRun(tx as unknown as DB, {
+      const r = createWorkflowRun(tx, {
         workflowId: id,
         triggeredBy: body.triggeredBy ?? "agent",
         triggeredById: body.triggeredById,
@@ -49,7 +49,7 @@ export async function POST(req: Request, { params }: RouteParams): Promise<NextR
         })
         .run();
 
-      createActivityEvent(tx as unknown as DB, {
+      createActivityEvent(tx, {
         source: "agent",
         type: "workflow_run.started",
         title: `Workflow run started: ${workflow.name}`,

--- a/apps/web/app/api/workflows/route.ts
+++ b/apps/web/app/api/workflows/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { events, createActivityEvent, type DB } from "@clawops/core";
+import { events, createActivityEvent } from "@clawops/core";
 import {
   createWorkflowDefinition,
   listWorkflowDefinitions,
@@ -77,7 +77,7 @@ export async function POST(req: Request): Promise<NextResponse> {
     }
 
     const workflow = db.transaction((tx) => {
-      const w = createWorkflowDefinition(tx as unknown as DB, {
+      const w = createWorkflowDefinition(tx, {
         name: body.name,
         description: body.description,
         version: body.version,
@@ -96,7 +96,7 @@ export async function POST(req: Request): Promise<NextResponse> {
           meta: JSON.stringify({ name: w.name }),
         })
         .run();
-      createActivityEvent(tx as unknown as DB, {
+      createActivityEvent(tx, {
         source: "agent",
         type: "workflow.created",
         title: `Workflow created: ${w.name}`,

--- a/apps/web/app/openclaw/files/[fileId]/actions.ts
+++ b/apps/web/app/openclaw/files/[fileId]/actions.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { revertTrackedOpenClawFile, OpenClawActionError } from "@clawops/sync/openclaw";
-import { events, createActivityEvent, type DB } from "@clawops/core";
+import { events, createActivityEvent } from "@clawops/core";
 import { getDb } from "@/lib/server/runtime";
 
 export async function revertFileRevisionAction(
@@ -27,7 +27,7 @@ export async function revertFileRevisionAction(
         })
         .run();
 
-      createActivityEvent(tx as unknown as DB, {
+      createActivityEvent(tx, {
         source: "user",
         severity: "info",
         type: "file.reverted",

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -1,10 +1,7 @@
 import { and, eq } from "drizzle-orm";
-import type { Agent, DB, OpenClawAgent } from "@clawops/core";
+import type { DBOrTx, Agent, OpenClawAgent } from "@clawops/core";
 import { agents, openclawAgents, toJsonArray } from "@clawops/core";
 import { generateId, hashApiKey, type AgentStatus } from "@clawops/domain";
-
-/** Subset of DB that both the root connection and a transaction satisfy. */
-type Queryable = Pick<DB, "insert" | "update" | "select" | "delete">;
 
 interface CreateAgentInput {
   name: string;
@@ -50,7 +47,7 @@ interface OpenClawIdentityLookupInput {
  * @returns The OpenClaw agent mapping if found, null otherwise
  */
 export function getOpenClawAgentMapping(
-  db: DB,
+  db: DBOrTx,
   connectionId: string,
   externalAgentId: string,
 ): OpenClawAgent | null {
@@ -74,7 +71,7 @@ export function getOpenClawAgentMapping(
  * @returns The OpenClaw agent mapping if found, null otherwise
  */
 export function getOpenClawMappingByAgentId(
-  db: DB,
+  db: DBOrTx,
   agentId: string,
 ): OpenClawAgent | null {
   return db
@@ -92,7 +89,7 @@ export function getOpenClawMappingByAgentId(
  * @returns The ClawOps agent if found, null otherwise
  */
 export function getAgentByOpenClawIdentity(
-  db: DB,
+  db: DBOrTx,
   input: OpenClawIdentityLookupInput,
 ): Agent | null {
   const rows = db
@@ -112,7 +109,7 @@ export function getAgentByOpenClawIdentity(
 }
 
 function findSingleAgentByNameAndFramework(
-  db: DB,
+  db: DBOrTx,
   input: InitAgentInput,
 ): Agent | null {
   const rows = db
@@ -134,7 +131,7 @@ function findSingleAgentByNameAndFramework(
  * @throws Error if the upsert operation fails
  */
 export function upsertOpenClawAgentIdentity(
-  db: Queryable,
+  db: DBOrTx,
   input: NonNullable<InitAgentInput["openclaw"]> & { linkedAgentId: string },
 ): OpenClawAgent {
   const now = new Date();
@@ -187,7 +184,7 @@ export function upsertOpenClawAgentIdentity(
  * @throws Error if agent creation fails
  */
 export function createAgent(
-  db: DB,
+  db: DBOrTx,
   input: CreateAgentInput,
 ): Agent & { apiKey: string } {
   const rawKey = generateId();
@@ -222,7 +219,7 @@ export function createAgent(
  * @param id - The agent ID
  * @returns The agent if found, null otherwise
  */
-export function getAgent(db: DB, id: string): Agent | null {
+export function getAgent(db: DBOrTx, id: string): Agent | null {
   const rows = db
     .select()
     .from(agents)
@@ -237,7 +234,7 @@ export function getAgent(db: DB, id: string): Agent | null {
  * @param db - Database instance
  * @returns Array of all agents
  */
-export function listAgents(db: DB): Agent[] {
+export function listAgents(db: DBOrTx): Agent[] {
   return db.select().from(agents).all();
 }
 
@@ -251,7 +248,7 @@ export function listAgents(db: DB): Agent[] {
  * @throws Error if agent not found
  */
 export function updateAgentStatus(
-  db: DB,
+  db: DBOrTx,
   id: string,
   status: AgentStatus,
   _message?: string,
@@ -284,7 +281,7 @@ export function updateAgentStatus(
  * @throws Error if agent not found
  */
 export function updateAgentSkills(
-  db: DB,
+  db: DBOrTx,
   id: string,
   skills: string[],
 ): Agent {
@@ -309,7 +306,7 @@ export function updateAgentSkills(
  * @param hashedKey - The hashed API key
  * @returns The agent if found, null otherwise
  */
-export function getAgentByApiKey(db: DB, hashedKey: string): Agent | null {
+export function getAgentByApiKey(db: DBOrTx, hashedKey: string): Agent | null {
   const rows = db
     .select()
     .from(agents)
@@ -330,7 +327,7 @@ export function getAgentByApiKey(db: DB, hashedKey: string): Agent | null {
  * Callers that omit `input.openclaw` still fall back to name/framework matching.
  */
 export function initAgent(
-  db: DB,
+  db: DBOrTx,
   input: InitAgentInput,
 ): { agent: Agent; apiKey?: string; created: boolean } {
   const existing =
@@ -364,7 +361,7 @@ export function initAgent(
       }
 
       if (input.openclaw) {
-        upsertOpenClawAgentIdentity(tx as unknown as DB, {
+        upsertOpenClawAgentIdentity(tx, {
           ...input.openclaw,
           linkedAgentId: updated.id,
           memoryPath:
@@ -407,7 +404,7 @@ export function initAgent(
     }
 
     if (input.openclaw) {
-      upsertOpenClawAgentIdentity(tx as unknown as DB, {
+      upsertOpenClawAgentIdentity(tx, {
         ...input.openclaw,
         linkedAgentId: created.id,
         memoryPath:

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -1,5 +1,5 @@
 import { eq, and, gte, lte, sum, count, sql, type SQL } from "drizzle-orm";
-import type { DB } from "@clawops/core";
+import type { DBOrTx } from "@clawops/core";
 import { usageLogs, tasks, taskTemplates } from "@clawops/core";
 
 // ── Token aggregation ──────────────────────────────────────────────────────
@@ -28,7 +28,7 @@ interface TokenSummary {
  * @param filters - Optional filters to narrow the aggregation.
  * @returns A summary with `totalIn`, `totalOut`, `totalCost`, and `count`.
  */
-export function getTokenSummary(db: DB, filters: TokenFilters): TokenSummary {
+export function getTokenSummary(db: DBOrTx, filters: TokenFilters): TokenSummary {
   const conditions: SQL[] = [];
 
   if (filters.agentId) {
@@ -81,7 +81,7 @@ interface CostByGroup {
  * @param db - Drizzle database handle.
  * @returns An array of cost summaries, one per agent.
  */
-export function getCostsByAgent(db: DB): CostByGroup[] {
+export function getCostsByAgent(db: DBOrTx): CostByGroup[] {
   const rows = db
     .select({
       group: usageLogs.agentId,
@@ -109,7 +109,7 @@ export function getCostsByAgent(db: DB): CostByGroup[] {
  * @param db - Drizzle database handle.
  * @returns An array of cost summaries, one per model.
  */
-export function getCostsByModel(db: DB): CostByGroup[] {
+export function getCostsByModel(db: DBOrTx): CostByGroup[] {
   const rows = db
     .select({
       group: usageLogs.model,
@@ -139,7 +139,7 @@ export function getCostsByModel(db: DB): CostByGroup[] {
  * @param db - Drizzle database handle.
  * @returns An array of cost summaries, one per project.
  */
-export function getCostsByProject(db: DB): CostByGroup[] {
+export function getCostsByProject(db: DBOrTx): CostByGroup[] {
   const rows = db
     .select({
       group: tasks.projectId,
@@ -247,7 +247,7 @@ function truncateToGranularity(granularity: Granularity): SQL {
  * @returns Array of timeline points ordered by timestamp.
  */
 export function getTokenTimeline(
-  db: DB,
+  db: DBOrTx,
   filters: TimelineFilters,
 ): TimelinePoint[] {
   const { from, to, granularity = "day" } = filters;
@@ -299,7 +299,7 @@ export function getTokenTimeline(
  * @returns Array of cost timeline points ordered by timestamp.
  */
 export function getCostTimeline(
-  db: DB,
+  db: DBOrTx,
   filters: TimelineFilters,
 ): CostTimelinePoint[] {
   const { from, to, granularity = "day" } = filters;
@@ -352,7 +352,7 @@ interface CostByTemplate {
   count: number;
 }
 
-export function getCostsByTemplate(db: DB): CostByTemplate[] {
+export function getCostsByTemplate(db: DBOrTx): CostByTemplate[] {
   const rows = db
     .select({
       templateId: tasks.templateId,
@@ -378,6 +378,6 @@ export function getCostsByTemplate(db: DB): CostByTemplate[] {
   }));
 }
 
-export function getTokensByTemplate(db: DB): CostByTemplate[] {
+export function getTokensByTemplate(db: DBOrTx): CostByTemplate[] {
   return getCostsByTemplate(db);
 }

--- a/packages/core/src/db.ts
+++ b/packages/core/src/db.ts
@@ -10,3 +10,6 @@ sqlite.pragma("foreign_keys = ON");
 
 export const db = drizzle(sqlite, { schema });
 export type DB = typeof db;
+
+export type TransactionDb = Parameters<DB["transaction"]>[0] extends (tx: infer T) => unknown ? T : DB;
+export type DBOrTx = DB | TransactionDb;

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -1,5 +1,5 @@
 import { and, desc, eq, type SQL } from "drizzle-orm";
-import type { DB } from "./db.js";
+import type { DBOrTx } from "./db.js";
 import {
   activityEvents,
   type ActivityEvent,
@@ -104,7 +104,7 @@ export function normalizeActivityEvent(
 }
 
 export function createActivityEvent(
-  db: DB,
+  db: DBOrTx,
   event: Omit<NewActivityEvent, "id" | "createdAt">,
 ): ActivityEvent {
   return db
@@ -319,7 +319,7 @@ function normalizeWorkflowDefinitionInput(
 }
 
 export function createWorkflowDefinition(
-  db: DB,
+  db: DBOrTx,
   input: CreateWorkflowDefinitionInput,
 ): WorkflowDefinitionRecord {
   const row = db
@@ -332,7 +332,7 @@ export function createWorkflowDefinition(
 }
 
 export function getWorkflowDefinition(
-  db: DB,
+  db: DBOrTx,
   id: string,
 ): WorkflowDefinitionRecord | null {
   const row = db
@@ -345,7 +345,7 @@ export function getWorkflowDefinition(
 }
 
 export function listWorkflowDefinitions(
-  db: DB,
+  db: DBOrTx,
   filters: ListWorkflowDefinitionFilters = {},
 ): WorkflowDefinitionRecord[] {
   const conditions: SQL[] = [];
@@ -375,7 +375,7 @@ export function listWorkflowDefinitions(
 }
 
 export function startWorkflowRun(
-  db: DB,
+  db: DBOrTx,
   input: StartWorkflowRunInput,
 ): WorkflowRunRecord {
   const row = db
@@ -397,7 +397,7 @@ export function startWorkflowRun(
 }
 
 export function recordWorkflowRunStep(
-  db: DB,
+  db: DBOrTx,
   input: RecordWorkflowRunStepInput,
 ): WorkflowRunStepRecord {
   const stepName = input.stepName.trim();
@@ -427,7 +427,7 @@ export function recordWorkflowRunStep(
 }
 
 export function finishWorkflowRun(
-  db: DB,
+  db: DBOrTx,
   runId: string,
   input: FinishWorkflowRunInput = {},
 ): WorkflowRunRecord {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-export type { DB } from "./db.js";
+export type { DB, DBOrTx } from "./db.js";
 export * from "./schema.js";
 export type { SQL } from "drizzle-orm";
 export {

--- a/packages/habits/src/index.ts
+++ b/packages/habits/src/index.ts
@@ -1,5 +1,5 @@
 import { eq, and, gte, desc } from "drizzle-orm";
-import type { DB } from "@clawops/core";
+import type { DBOrTx } from "@clawops/core";
 import { habits, habitRuns } from "@clawops/core";
 import type { Habit, HabitRun } from "@clawops/core";
 import { HabitType, HabitStatus } from "@clawops/domain";
@@ -18,7 +18,7 @@ interface CreateHabitInput {
 }
 
 export function createHabit(
-  db: DB,
+  db: DBOrTx,
   agentId: string,
   input: CreateHabitInput,
 ): Habit {
@@ -41,7 +41,7 @@ export function createHabit(
 
 // ── listHabits ─────────────────────────────────────────────────────────────
 
-export function listHabits(db: DB, agentId?: string): Habit[] {
+export function listHabits(db: DBOrTx, agentId?: string): Habit[] {
   if (agentId) {
     return db.select().from(habits).where(eq(habits.agentId, agentId)).all();
   }
@@ -59,7 +59,7 @@ interface UpdateHabitInput {
 }
 
 export function updateHabit(
-  db: DB,
+  db: DBOrTx,
   id: string,
   updates: UpdateHabitInput,
 ): Habit {
@@ -86,7 +86,7 @@ interface LogHabitRunInput {
 }
 
 export function logHabitRun(
-  db: DB,
+  db: DBOrTx,
   habitId: string,
   agentId: string,
   input: LogHabitRunInput,
@@ -138,7 +138,7 @@ interface StreakEntry {
 }
 
 export function getHabitStreak(
-  db: DB,
+  db: DBOrTx,
   habitId: string,
   days: number = 7,
 ): StreakEntry[] {
@@ -190,7 +190,7 @@ export function getHabitStreak(
 
 // ── logHeartbeat ───────────────────────────────────────────────────────────
 
-export function logHeartbeat(db: DB, agentId: string): HabitRun {
+export function logHeartbeat(db: DBOrTx, agentId: string): HabitRun {
   return db.transaction((tx) => {
     // Find existing heartbeat habit for this agent
     let habit = tx

--- a/packages/habits/src/openclaw.ts
+++ b/packages/habits/src/openclaw.ts
@@ -6,7 +6,7 @@ import {
   habits,
   openclawAgents,
   openclawConnections,
-  type DB,
+  type DBOrTx,
   type Habit,
   type OpenClawConnection,
 } from "@clawops/core";
@@ -172,7 +172,7 @@ function resolveGatewayToken(connection: OpenClawConnection, token?: string): st
   return resolved;
 }
 
-function getConnectionOrThrow(db: DB, connectionId: string): ConnectionRecord {
+function getConnectionOrThrow(db: DBOrTx, connectionId: string): ConnectionRecord {
   const connection = db
     .select()
     .from(openclawConnections)
@@ -191,7 +191,7 @@ function getConnectionOrThrow(db: DB, connectionId: string): ConnectionRecord {
 }
 
 function resolveAgentId(
-  db: DB,
+  db: DBOrTx,
   connectionId: string,
   sessionTarget: string | null,
   existingAgentId: string | null,
@@ -276,7 +276,7 @@ export async function fetchCronJobs(
 }
 
 export function listCronJobs(
-  db: DB,
+  db: DBOrTx,
   filters: {
     connectionId?: string;
   } = {},
@@ -295,12 +295,12 @@ export function listCronJobs(
   return query.where(eq(habits.type, "cron")).all();
 }
 
-export function getCronJob(db: DB, id: string): Habit | null {
+export function getCronJob(db: DBOrTx, id: string): Habit | null {
   return db.select().from(habits).where(eq(habits.id, id)).get() ?? null;
 }
 
 export function upsertCronJobs(
-  db: DB,
+  db: DBOrTx,
   connectionId: string,
   jobs: OpenClawCronJob[],
 ): Habit[] {
@@ -319,7 +319,7 @@ export function upsertCronJobs(
         )
         .get();
 
-      const agentId = resolveAgentId(tx as unknown as DB, connectionId, job.sessionTarget, existing?.agentId ?? null);
+      const agentId = resolveAgentId(tx, connectionId, job.sessionTarget, existing?.agentId ?? null);
       const values = {
         connectionId,
         agentId,
@@ -397,7 +397,7 @@ export async function updateCronJob(
 }
 
 export async function syncCronJobs(
-  db: DB,
+  db: DBOrTx,
   connection: OpenClawConnection,
   token?: string,
 ): Promise<Habit[]> {
@@ -414,7 +414,7 @@ export async function syncCronJobs(
 }
 
 export function updateLocalCronJob(
-  db: DB,
+  db: DBOrTx,
   id: string,
   updates: Partial<Pick<Habit, "name" | "schedule" | "cronExpr" | "scheduleKind" | "scheduleExpr" | "sessionTarget" | "enabled" | "status" | "lastSyncedAt">>,
 ): Habit {
@@ -433,7 +433,7 @@ export function updateLocalCronJob(
 }
 
 export async function updateConnectionCronJob(
-  db: DB,
+  db: DBOrTx,
   localCronJobId: string,
   patch: UpdateCronJobPatch,
   token?: string,

--- a/packages/ideas/src/index.ts
+++ b/packages/ideas/src/index.ts
@@ -1,5 +1,5 @@
 import { eq, and } from "drizzle-orm";
-import type { DB, Idea, NewIdea, Project, Task } from "@clawops/core";
+import type { DBOrTx, Idea, NewIdea, Project, Task } from "@clawops/core";
 import { ideas, projects, tasks, parseJsonArray, toJsonArray, parseJsonObject, toJsonObject } from "@clawops/core";
 import type { IdeaStatus, TaskStatus, TaskPriority, Source } from "@clawops/domain";
 import { NotFoundError, ConflictError } from "@clawops/domain";
@@ -19,7 +19,7 @@ export type IdeaSectionKey = (typeof IDEA_SECTION_KEYS)[number];
  */
 export type IdeaSections = Partial<Record<IdeaSectionKey, string>>;
 
-function getIdeaSectionsRow(db: DB, id: string): { sections: string | null } {
+function getIdeaSectionsRow(db: DBOrTx, id: string): { sections: string | null } {
   const [idea] = db
     .select({ sections: ideas.sections })
     .from(ideas)
@@ -34,7 +34,7 @@ function getIdeaSectionsRow(db: DB, id: string): { sections: string | null } {
 }
 
 export function createIdea(
-  db: DB,
+  db: DBOrTx,
   input: { title: string; description?: string; tags?: string[]; sections?: IdeaSections; source?: NewIdea["source"] },
 ): Idea {
   const [idea] = db
@@ -52,7 +52,7 @@ export function createIdea(
 }
 
 export function listIdeas(
-  db: DB,
+  db: DBOrTx,
   filters?: { status?: IdeaStatus; tag?: string },
 ): Idea[] {
   let result: Idea[];
@@ -76,7 +76,7 @@ export function listIdeas(
 }
 
 export function updateIdea(
-  db: DB,
+  db: DBOrTx,
   id: string,
   updates: Partial<{
     title: string;
@@ -105,7 +105,7 @@ export function updateIdea(
 /**
  * Get all sections for an idea
  */
-export function getIdeaSections(db: DB, id: string): IdeaSections {
+export function getIdeaSections(db: DBOrTx, id: string): IdeaSections {
   const idea = getIdeaSectionsRow(db, id);
   if (!idea.sections) {
     return {};
@@ -116,7 +116,7 @@ export function getIdeaSections(db: DB, id: string): IdeaSections {
 /**
  * Get a specific section from an idea
  */
-export function getIdeaSection(db: DB, id: string, section: IdeaSectionKey): string | null {
+export function getIdeaSection(db: DBOrTx, id: string, section: IdeaSectionKey): string | null {
   const sections = getIdeaSections(db, id);
   return sections[section] ?? null;
 }
@@ -125,7 +125,7 @@ export function getIdeaSection(db: DB, id: string, section: IdeaSectionKey): str
  * Update a specific section of an idea
  */
 export function updateIdeaSection(
-  db: DB,
+  db: DBOrTx,
   id: string,
   section: IdeaSectionKey,
   content: string,
@@ -151,7 +151,7 @@ export function updateIdeaSection(
  * Update multiple sections of an idea at once
  */
 export function updateIdeaSections(
-  db: DB,
+  db: DBOrTx,
   id: string,
   sections: Partial<IdeaSections>,
 ): Idea {
@@ -175,14 +175,14 @@ export function updateIdeaSections(
 /**
  * Get the draft PRD content from an idea
  */
-export function getIdeaDraftPrd(db: DB, id: string): string | null {
+export function getIdeaDraftPrd(db: DBOrTx, id: string): string | null {
   return getIdeaSection(db, id, "draftPrd");
 }
 
 /**
  * Set the draft PRD content for an idea
  */
-export function setIdeaDraftPrd(db: DB, id: string, content: string): Idea {
+export function setIdeaDraftPrd(db: DBOrTx, id: string, content: string): Idea {
   return updateIdeaSection(db, id, "draftPrd", content);
 }
 
@@ -190,7 +190,7 @@ export function setIdeaDraftPrd(db: DB, id: string, content: string): Idea {
  * List all tasks linked to an idea
  */
 export function listIdeaTasks(
-  db: DB,
+  db: DBOrTx,
   ideaId: string,
   filters?: { status?: TaskStatus },
 ): Task[] {
@@ -211,7 +211,7 @@ export function listIdeaTasks(
  * Create a task linked to an idea
  */
 export function createIdeaTask(
-  db: DB,
+  db: DBOrTx,
   ideaId: string,
   input: {
     title: string;
@@ -251,7 +251,7 @@ export function createIdeaTask(
 }
 
 export function promoteIdeaToProject(
-  db: DB,
+  db: DBOrTx,
   ideaId: string,
 ): { idea: Idea; project: Project } {
   const [existing] = db

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -1,5 +1,5 @@
 import { eq, desc, count } from "drizzle-orm";
-import type { DB, Notification } from "@clawops/core";
+import type { DBOrTx, Notification } from "@clawops/core";
 import { notifications } from "@clawops/core";
 import { generateId } from "@clawops/domain";
 
@@ -16,7 +16,7 @@ interface ListNotificationFilters {
 }
 
 export function createNotification(
-  db: DB,
+  db: DBOrTx,
   input: CreateNotificationInput,
 ): Notification {
   const [notification] = db
@@ -35,7 +35,7 @@ export function createNotification(
 }
 
 export function listNotifications(
-  db: DB,
+  db: DBOrTx,
   filters?: ListNotificationFilters,
 ): Notification[] {
   const query = db.select().from(notifications);
@@ -50,7 +50,7 @@ export function listNotifications(
   return query.orderBy(desc(notifications.createdAt)).all();
 }
 
-export function markRead(db: DB, id: string): Notification {
+export function markRead(db: DBOrTx, id: string): Notification {
   const [notification] = db
     .update(notifications)
     .set({ read: true })
@@ -60,14 +60,14 @@ export function markRead(db: DB, id: string): Notification {
   return notification;
 }
 
-export function markAllRead(db: DB): void {
+export function markAllRead(db: DBOrTx): void {
   db.update(notifications)
     .set({ read: true })
     .where(eq(notifications.read, false))
     .run();
 }
 
-export function getUnreadCount(db: DB): number {
+export function getUnreadCount(db: DBOrTx): number {
   const [result] = db
     .select({ value: count() })
     .from(notifications)

--- a/packages/projects/src/index.ts
+++ b/packages/projects/src/index.ts
@@ -1,5 +1,5 @@
 import { eq, and, count } from "drizzle-orm";
-import type { DB } from "@clawops/core";
+import type { DBOrTx } from "@clawops/core";
 import {
   projects,
   milestones,
@@ -13,13 +13,13 @@ import type { ProjectStatus, MilestoneStatus } from "@clawops/domain";
 
 // ── Project Spec ──────────────────────────────────────────────────────────────
 
-export function getProjectSpec(db: DB, id: string): string | null {
+export function getProjectSpec(db: DBOrTx, id: string): string | null {
   const project = db.select().from(projects).where(eq(projects.id, id)).get();
   return project?.specContent ?? null;
 }
 
 export function setProjectSpec(
-  db: DB,
+  db: DBOrTx,
   id: string,
   specContent: string,
 ): Project {
@@ -36,7 +36,7 @@ export function setProjectSpec(
 }
 
 export function appendProjectSpec(
-  db: DB,
+  db: DBOrTx,
   id: string,
   content: string,
 ): Project {
@@ -61,7 +61,7 @@ export function appendProjectSpec(
 }
 
 export function createProject(
-  db: DB,
+  db: DBOrTx,
   input: { name: string; description?: string; status?: ProjectStatus; prd?: string; ideaId?: string },
 ): Project {
   const project = db
@@ -80,7 +80,7 @@ export function createProject(
 }
 
 export function getProject(
-  db: DB,
+  db: DBOrTx,
   id: string,
 ): (Project & { milestones: Milestone[]; taskCount: number }) | null {
   const project = db.select().from(projects).where(eq(projects.id, id)).get();
@@ -106,12 +106,12 @@ export function getProject(
   };
 }
 
-export function listProjects(db: DB): Project[] {
+export function listProjects(db: DBOrTx): Project[] {
   return db.select().from(projects).all();
 }
 
 export function updateProject(
-  db: DB,
+  db: DBOrTx,
   id: string,
   updates: Partial<{ name: string; description: string; status: ProjectStatus; prd: string }>,
 ): Project {
@@ -132,7 +132,7 @@ export function updateProject(
 // ── Milestones ───────────────────────────────────────────────────────────────
 
 export function createMilestone(
-  db: DB,
+  db: DBOrTx,
   projectId: string,
   input: { title: string; order?: number },
 ): Milestone {
@@ -157,7 +157,7 @@ export function createMilestone(
 }
 
 export function updateMilestone(
-  db: DB,
+  db: DBOrTx,
   id: string,
   updates: Partial<{ title: string; status: MilestoneStatus; order: number }>,
 ): Milestone {
@@ -171,7 +171,7 @@ export function updateMilestone(
 }
 
 export function reorderMilestones(
-  db: DB,
+  db: DBOrTx,
   projectId: string,
   orderedIds: string[],
 ): Milestone[] {
@@ -191,7 +191,7 @@ export function reorderMilestones(
 // ── Progress ─────────────────────────────────────────────────────────────────
 
 export function getProjectProgress(
-  db: DB,
+  db: DBOrTx,
   id: string,
 ): { total: number; completed: number; percent: number } {
   const totalResult = db
@@ -245,7 +245,7 @@ export interface ProjectContext {
 }
 
 export function getProjectContext(
-  db: DB,
+  db: DBOrTx,
   projectId: string,
   options?: { minimal?: boolean },
 ): ProjectContext | null {
@@ -370,7 +370,7 @@ export function getProjectContext(
 // ── Session Management ───────────────────────────────────────────────────────
 
 export function activateProject(
-  db: DB,
+  db: DBOrTx,
   agentId: string,
   projectId: string,
 ): AgentSession {
@@ -411,7 +411,7 @@ export function activateProject(
 }
 
 export function deactivateProject(
-  db: DB,
+  db: DBOrTx,
   agentId: string,
   summary: string,
 ): AgentSession | null {
@@ -443,7 +443,7 @@ export function deactivateProject(
 }
 
 export function getActiveSession(
-  db: DB,
+  db: DBOrTx,
   agentId: string,
 ): AgentSession | null {
   const session = db

--- a/packages/sync/src/connections.ts
+++ b/packages/sync/src/connections.ts
@@ -3,11 +3,9 @@ import {
   eq,
   openclawConnections,
   toJsonObject,
-  type DB,
+  type DBOrTx,
   type OpenClawConnection,
 } from "@clawops/core";
-
-type TransactionDb = Parameters<DB["transaction"]>[0] extends (tx: infer T) => unknown ? T : DB;
 
 export type OpenClawConnectionStatus = "active" | "disconnected" | "error";
 export type OpenClawConnectionSyncMode = "manual" | "hybrid";
@@ -56,7 +54,7 @@ function buildConnectionUpdateValues(
   };
 }
 
-export function listOpenClawConnections(db: DB): OpenClawConnection[] {
+export function listOpenClawConnections(db: DBOrTx): OpenClawConnection[] {
   return db
     .select()
     .from(openclawConnections)
@@ -65,7 +63,7 @@ export function listOpenClawConnections(db: DB): OpenClawConnection[] {
 }
 
 export function getOpenClawConnection(
-  db: DB,
+  db: DBOrTx,
   id: string,
 ): OpenClawConnection | null {
   return db
@@ -76,7 +74,7 @@ export function getOpenClawConnection(
 }
 
 export function getOpenClawConnectionByRootPath(
-  db: DB,
+  db: DBOrTx,
   rootPath: string,
 ): OpenClawConnection | null {
   return db
@@ -87,12 +85,12 @@ export function getOpenClawConnectionByRootPath(
 }
 
 export function upsertOpenClawConnection(
-  db: DB,
+  db: DBOrTx,
   input: UpsertOpenClawConnectionInput,
 ): { connection: OpenClawConnection; created: boolean } {
   // Use a transaction + INSERT with ON CONFLICT to avoid the read-then-insert race condition.
   // SQLite's unique constraint on rootPath ensures atomicity.
-  return db.transaction((tx: TransactionDb) => {
+  return db.transaction((tx) => {
     const now = new Date();
 
     // Attempt insert; conflict means the row already exists.
@@ -143,7 +141,7 @@ export function upsertOpenClawConnection(
 }
 
 export function updateOpenClawConnection(
-  db: DB,
+  db: DBOrTx,
   id: string,
   updates: UpdateOpenClawConnectionInput,
 ): OpenClawConnection | null {

--- a/packages/sync/src/events.ts
+++ b/packages/sync/src/events.ts
@@ -12,7 +12,7 @@ import {
   parseJsonObject,
   toJsonObject,
   type ActivityEvent,
-  type DB,
+  type DBOrTx,
   type Event,
   type Habit,
   type OpenClawConnection,
@@ -20,8 +20,6 @@ import {
 } from "@clawops/core";
 import { AgentStatus } from "@clawops/domain";
 import { logHabitRun, logHeartbeat } from "@clawops/habits";
-
-type TransactionDb = Parameters<DB["transaction"]>[0] extends (tx: infer T) => unknown ? T : DB;
 
 type SupportedInboundType =
   | "agent.heartbeat"
@@ -385,7 +383,7 @@ export function normalizeOpenClawInboundEvent(
   };
 }
 
-function requireConnection(db: DB, connectionId: string): OpenClawConnection {
+function requireConnection(db: DBOrTx, connectionId: string): OpenClawConnection {
   const connection = db
     .select()
     .from(openclawConnections)
@@ -403,7 +401,7 @@ function requireConnection(db: DB, connectionId: string): OpenClawConnection {
 }
 
 function insertLowLevelEvent(
-  db: DB,
+  db: DBOrTx,
   input: {
     occurredAt: Date;
     agentId?: string | null;
@@ -434,7 +432,7 @@ function insertLowLevelEvent(
 }
 
 function recordActivity(
-  db: DB,
+  db: DBOrTx,
   input: {
     occurredAt: Date;
     type: string;
@@ -474,7 +472,7 @@ function recordActivity(
 }
 
 function requireMappedAgent(
-  db: DB,
+  db: DBOrTx,
   connectionId: string,
   externalAgentId: string,
 ) {
@@ -494,7 +492,7 @@ function requireMappedAgent(
 }
 
 function upsertOpenClawSessionState(
-  db: DB,
+  db: DBOrTx,
   input: {
     connectionId: string;
     sessionKey: string;
@@ -614,7 +612,7 @@ function upsertOpenClawSessionState(
 }
 
 function requireCronJob(
-  db: DB,
+  db: DBOrTx,
   connectionId: string,
   externalId: string,
 ): Habit {
@@ -641,7 +639,7 @@ function requireCronJob(
 }
 
 function ingestOpenClawInboundEventTx(
-  db: DB,
+  db: DBOrTx,
   normalizedEvent: NormalizedOpenClawInboundEvent,
 ): OpenClawInboundEventIngestResult {
   const connection = requireConnection(db, normalizedEvent.connectionId);
@@ -881,12 +879,12 @@ function ingestOpenClawInboundEventTx(
 }
 
 export function ingestOpenClawInboundEvent(
-  db: DB,
+  db: DBOrTx,
   input: unknown,
 ): OpenClawInboundEventIngestResult {
   const normalizedEvent = normalizeOpenClawInboundEvent(input);
 
-  return db.transaction((tx: TransactionDb) =>
-    ingestOpenClawInboundEventTx(tx as unknown as DB, normalizedEvent),
+  return db.transaction((tx) =>
+    ingestOpenClawInboundEventTx(tx, normalizedEvent),
   );
 }

--- a/packages/sync/src/onboarding.ts
+++ b/packages/sync/src/onboarding.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { initAgent } from "@clawops/agents";
-import { events, type DB, type OpenClawConnection } from "@clawops/core";
+import { events, type DBOrTx, type OpenClawConnection } from "@clawops/core";
 import { upsertCronJobs } from "@clawops/habits";
 import { upsertOpenClawConnection, type OpenClawConnectionSyncMode } from "./connections.js";
 import { fetchGatewayCronJobs, scanOpenClaw } from "./openclaw/index.js";
@@ -11,8 +11,6 @@ import { syncWorkspaceFiles } from "./openclaw/files.js";
 import { syncSessions } from "./openclaw/sessions.js";
 import { finishSyncRunWithTx, startSyncRun } from "./runs.js";
 import type { SyncAgent, SyncCronJob, SyncWorkspace } from "./types.js";
-
-type TransactionDb = Parameters<DB["transaction"]>[0] extends (tx: infer T) => unknown ? T : DB;
 
 export interface OpenClawOnboardingInput {
   source: string;
@@ -108,7 +106,7 @@ function validateOpenClawDir(
 }
 
 export async function onboardOpenClaw(
-  db: DB,
+  db: DBOrTx,
   input: OpenClawOnboardingInput,
   dependencies: OnboardingDependencies = defaultDependencies,
 ): Promise<OpenClawOnboardingResult> {
@@ -141,8 +139,8 @@ export async function onboardOpenClaw(
     const syncedAt = new Date();
     let connectionForFileSync: OpenClawConnection | null = null;
 
-    const result = db.transaction((tx: TransactionDb) => {
-      const connection = dependencies.upsertOpenClawConnection(tx as unknown as DB, {
+    const result = db.transaction((tx) => {
+      const connection = dependencies.upsertOpenClawConnection(tx, {
         name: input.connectionName ?? defaultConnectionName(openclawDir),
         rootPath: openclawDir,
         gatewayUrl: scanResult.gatewayUrl,
@@ -179,7 +177,7 @@ export async function onboardOpenClaw(
         .run();
 
       const agentRegistrations = scanResult.agents.map((discovered) => {
-        const registration = dependencies.initAgent(tx as unknown as DB, {
+        const registration = dependencies.initAgent(tx, {
           name: discovered.name,
           model: discovered.model ?? "unknown",
           role: discovered.role ?? "agent",
@@ -226,7 +224,7 @@ export async function onboardOpenClaw(
       });
 
       dependencies.upsertCronJobs(
-        tx as unknown as DB,
+        tx,
         connection.connection.id,
         cronJobs.map((job) => ({
           id: job.id,
@@ -241,7 +239,7 @@ export async function onboardOpenClaw(
         })),
       );
 
-      dependencies.finishSyncRunWithTx(tx as unknown as DB, run.id, {
+      dependencies.finishSyncRunWithTx(tx, run.id, {
         connectionId: connection.connection.id,
         status: "success",
         agentCount: scanResult.agents.length,
@@ -333,8 +331,8 @@ export async function onboardOpenClaw(
     return result;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    db.transaction((tx: TransactionDb) => {
-      dependencies.finishSyncRunWithTx(tx as unknown as DB, run.id, {
+    db.transaction((tx) => {
+      dependencies.finishSyncRunWithTx(tx, run.id, {
         status: "failed",
         error: message,
         meta: {

--- a/packages/sync/src/openclaw/actions.ts
+++ b/packages/sync/src/openclaw/actions.ts
@@ -3,7 +3,7 @@ import {
   parseJsonObject,
   workspaceFileRevisions,
   workspaceFiles,
-  type DB,
+  type DBOrTx,
   type OpenClawConnection,
 } from "@clawops/core";
 import {
@@ -176,7 +176,7 @@ async function requestGatewayAction(
   return { status: response.status, body: responseBody };
 }
 
-function requireConnection(db: DB, connectionId: string): OpenClawConnection {
+function requireConnection(db: DBOrTx, connectionId: string): OpenClawConnection {
   const connection = getOpenClawConnection(db, connectionId);
   if (!connection) {
     throw createActionError(`OpenClaw connection "${connectionId}" not found`, {
@@ -311,7 +311,7 @@ export async function writeTrackedFile(
 }
 
 export async function updateOpenClawCronAction(
-  db: DB,
+  db: DBOrTx,
   input: UpdateOpenClawCronActionInput,
 ): Promise<Awaited<ReturnType<typeof updateConnectionCronJob>>> {
   const job = getCronJob(db, input.cronJobId);
@@ -346,7 +346,7 @@ export async function updateOpenClawCronAction(
 }
 
 export async function writeTrackedOpenClawFile(
-  db: DB,
+  db: DBOrTx,
   input: WriteTrackedOpenClawFileInput,
 ): Promise<WriteTrackedFileResult | null> {
   const connection = requireConnection(db, input.connectionId);
@@ -370,7 +370,7 @@ export interface RevertTrackedOpenClawFileResult {
 }
 
 export async function revertTrackedOpenClawFile(
-  db: DB,
+  db: DBOrTx,
   input: RevertTrackedOpenClawFileInput,
 ): Promise<RevertTrackedOpenClawFileResult> {
   const revision = db
@@ -430,7 +430,7 @@ export async function revertTrackedOpenClawFile(
 }
 
 export async function triggerSupportedOpenClawEndpoint(
-  db: DB,
+  db: DBOrTx,
   input: TriggerSupportedOpenClawEndpointInput,
 ): Promise<TriggerSupportedOpenClawEndpointResult> {
   const connection = requireConnection(db, input.connectionId);

--- a/packages/sync/src/openclaw/files.ts
+++ b/packages/sync/src/openclaw/files.ts
@@ -10,13 +10,11 @@ import {
   sql,
   workspaceFileRevisions,
   workspaceFiles,
-  type DB,
+  type DBOrTx,
   type OpenClawConnection,
   type WorkspaceFile,
   type WorkspaceFileRevision,
 } from "@clawops/core";
-
-type TransactionDb = Parameters<DB["transaction"]>[0] extends (tx: infer T) => unknown ? T : DB;
 
 export interface OpenClawWorkspaceFile {
   workspacePath: string;
@@ -132,11 +130,11 @@ export async function fetchWorkspaceFiles(
 }
 
 export function upsertWorkspaceFiles(
-  db: DB,
+  db: DBOrTx,
   connectionId: string,
   files: OpenClawWorkspaceFile[],
 ): WorkspaceFileSyncResult {
-  return db.transaction((tx: TransactionDb) => {
+  return db.transaction((tx) => {
     const syncStartedAt = new Date();
     const existingRows = tx
       .select()
@@ -309,7 +307,7 @@ export function upsertWorkspaceFiles(
 }
 
 export function listWorkspaceFileRevisions(
-  db: DB,
+  db: DBOrTx,
   workspaceFileId: string,
   opts?: { limit?: number },
 ): WorkspaceFileRevision[] {
@@ -342,7 +340,7 @@ function resolveGatewayToken(connection: OpenClawConnection, tokenOverride?: str
 }
 
 export async function syncWorkspaceFiles(
-  db: DB,
+  db: DBOrTx,
   connection: OpenClawConnection,
   tokenOverride?: string,
 ): Promise<WorkspaceFileSyncResult> {

--- a/packages/sync/src/openclaw/messages.ts
+++ b/packages/sync/src/openclaw/messages.ts
@@ -5,7 +5,7 @@ import {
   agentMessages,
   toJsonObject,
   parseJsonObject,
-  type DB,
+  type DBOrTx,
   type AgentMessage,
   type SQL,
 } from "@clawops/core";
@@ -44,13 +44,13 @@ function deserializeMessage(row: AgentMessage): AgentMessageRecord {
   };
 }
 
-export function getAgentMessage(db: DB, id: string): AgentMessageRecord | null {
+export function getAgentMessage(db: DBOrTx, id: string): AgentMessageRecord | null {
   const row = db.select().from(agentMessages).where(eq(agentMessages.id, id)).get() ?? null;
   return row ? deserializeMessage(row) : null;
 }
 
 export function listAgentMessages(
-  db: DB,
+  db: DBOrTx,
   filters: AgentMessageFilters = {},
 ): AgentMessageRecord[] {
   const conditions: SQL[] = [];
@@ -93,7 +93,7 @@ export function listAgentMessages(
 }
 
 export function createAgentMessage(
-  db: DB,
+  db: DBOrTx,
   input: CreateAgentMessageInput,
 ): AgentMessageRecord {
   const row = db
@@ -117,7 +117,7 @@ export function createAgentMessage(
 }
 
 export function upsertAgentMessages(
-  db: DB,
+  db: DBOrTx,
   connectionId: string,
   messages: CreateAgentMessageInput[],
 ): AgentMessageRecord[] {

--- a/packages/sync/src/openclaw/sessions.ts
+++ b/packages/sync/src/openclaw/sessions.ts
@@ -7,7 +7,7 @@ import {
   openclawSessions,
   toJsonObject,
   parseJsonObject,
-  type DB,
+  type DBOrTx,
   type OpenClawConnection,
   type OpenClawSession,
 } from "@clawops/core";
@@ -207,7 +207,7 @@ export async function fetchActiveSessions(
 }
 
 export function upsertSessions(
-  db: DB,
+  db: DBOrTx,
   connectionId: string,
   sessions: FetchedOpenClawSession[],
 ): OpenClawSession[] {
@@ -248,7 +248,7 @@ export function upsertSessions(
 }
 
 export async function syncSessions(
-  db: DB,
+  db: DBOrTx,
   connection: OpenClawConnection,
   tokenOverride?: string,
 ): Promise<OpenClawSessionRecord[]> {
@@ -269,7 +269,7 @@ export async function syncSessions(
   }
 
   return db.transaction((tx) => {
-    const upserted = upsertSessions(tx as unknown as DB, connection.id, activeSessions);
+    const upserted = upsertSessions(tx, connection.id, activeSessions);
     const activeSessionKeys = activeSessions.map((session) => session.sessionKey);
     const previouslyActive = tx
       .select()
@@ -311,7 +311,7 @@ export async function syncSessions(
 }
 
 export function listSessions(
-  db: DB,
+  db: DBOrTx,
   filters: OpenClawSessionFilters = {},
 ): OpenClawSessionRecord[] {
   const conditions: SQL[] = [];

--- a/packages/sync/src/reconcile.ts
+++ b/packages/sync/src/reconcile.ts
@@ -1,6 +1,6 @@
 import {
   createActivityEvent,
-  type DB,
+  type DBOrTx,
   type OpenClawConnection,
   type SyncRunItem,
   type WorkspaceFile,
@@ -10,8 +10,6 @@ import { syncCronJobs } from "@clawops/habits";
 import { NotFoundError } from "@clawops/domain";
 import { syncWorkspaceFiles, type WorkspaceFileSyncResult } from "./openclaw/files.js";
 import { finishSyncRunWithTx, startSyncRun, type FinishSyncRunItemInput } from "./runs.js";
-
-type TransactionDb = Parameters<DB["transaction"]>[0] extends (tx: infer T) => unknown ? T : DB;
 
 /**
  * Reconciliation mode - controls which modules are synchronized.
@@ -113,7 +111,7 @@ function resolveGatewayToken(connection: OpenClawConnection, options?: Reconcile
  * Reconcile OpenClaw sessions.
  */
 async function reconcileSessions(
-  db: DB,
+  db: DBOrTx,
   connection: OpenClawConnection,
   options?: ReconcileOptions,
 ): Promise<{ agentCount: number; addedCount: number; updatedCount: number; items: FinishSyncRunItemInput[] }> {
@@ -146,7 +144,7 @@ async function reconcileSessions(
  * Reconcile cron jobs.
  */
 async function reconcileCronJobs(
-  db: DB,
+  db: DBOrTx,
   connection: OpenClawConnection,
   gatewayToken: string,
 ): Promise<{ cronJobCount: number; addedCount: number; updatedCount: number; items: FinishSyncRunItemInput[] }> {
@@ -180,7 +178,7 @@ async function reconcileCronJobs(
  * Reconcile workspace files.
  */
 async function reconcileFiles(
-  db: DB,
+  db: DBOrTx,
   connection: OpenClawConnection,
   options?: ReconcileOptions,
 ): Promise<{ workspaceCount: number; addedCount: number; updatedCount: number; items: FinishSyncRunItemInput[] }> {
@@ -212,7 +210,7 @@ async function reconcileFiles(
  * Execute reconciliation for a specific mode.
  */
 async function executeReconcileMode(
-  db: DB,
+  db: DBOrTx,
   ctx: ReconcileContext,
 ): Promise<{
   agentCount: number;
@@ -284,7 +282,7 @@ async function executeReconcileMode(
  * @returns Result of the reconciliation run
  */
 export async function reconcile(
-  db: DB,
+  db: DBOrTx,
   connection: OpenClawConnection,
   options: ReconcileOptions = {},
 ): Promise<ReconcileResult> {
@@ -311,8 +309,8 @@ export async function reconcile(
     const result = await executeReconcileMode(db, ctx);
 
     // Finish the sync run with results
-    const summary = db.transaction((tx: TransactionDb) => {
-      const syncResult = finishSyncRunWithTx(tx as unknown as DB, run.id, {
+    const summary = db.transaction((tx) => {
+      const syncResult = finishSyncRunWithTx(tx, run.id, {
         connectionId: connection.id,
         status: "success",
         agentCount: result.agentCount,
@@ -329,7 +327,7 @@ export async function reconcile(
       });
 
       try {
-        createActivityEvent(tx as unknown as DB, {
+        createActivityEvent(tx, {
           source: "sync",
           type: "sync.reconciled",
           title: `Reconciliation completed for ${connection.name} (${mode} mode)`,
@@ -366,8 +364,8 @@ export async function reconcile(
     };
   } catch (error) {
     // Mark sync run as failed
-    db.transaction((tx: TransactionDb) => {
-      finishSyncRunWithTx(tx as unknown as DB, run.id, {
+    db.transaction((tx) => {
+      finishSyncRunWithTx(tx, run.id, {
         status: "failed",
         error: error instanceof Error ? error.message : String(error),
         meta: {
@@ -377,7 +375,7 @@ export async function reconcile(
       });
 
       try {
-        createActivityEvent(tx as unknown as DB, {
+        createActivityEvent(tx, {
           source: "sync",
           severity: "error",
           type: "sync.reconcile_failed",
@@ -412,7 +410,7 @@ export async function reconcile(
  * @returns Result of the reconciliation run
  */
 export async function reconcileConnection(
-  db: DB,
+  db: DBOrTx,
   connectionId: string,
   options: ReconcileOptions = {},
 ): Promise<ReconcileResult> {

--- a/packages/sync/src/runs.ts
+++ b/packages/sync/src/runs.ts
@@ -7,12 +7,10 @@ import {
   syncRunItems,
   syncRuns,
   toJsonObject,
-  type DB,
+  type DBOrTx,
   type SyncRun,
   type SyncRunItem,
 } from "@clawops/core";
-
-type TransactionDb = Parameters<DB["transaction"]>[0] extends (tx: infer T) => unknown ? T : DB;
 
 export interface StartSyncRunInput {
   connectionId?: string;
@@ -61,7 +59,7 @@ function buildSyncRunSummary(
   };
 }
 
-function listSyncRunItemsByRunIds(db: DB, runIds: string[]): SyncRunItem[] {
+function listSyncRunItemsByRunIds(db: DBOrTx, runIds: string[]): SyncRunItem[] {
   if (runIds.length === 0) {
     return [];
   }
@@ -80,7 +78,7 @@ function listSyncRunItemsByRunIds(db: DB, runIds: string[]): SyncRunItem[] {
     .all();
 }
 
-export function startSyncRun(db: DB, input: StartSyncRunInput = {}): SyncRun {
+export function startSyncRun(db: DBOrTx, input: StartSyncRunInput = {}): SyncRun {
   const rows = db
     .insert(syncRuns)
     .values({
@@ -114,7 +112,7 @@ export function startSyncRun(db: DB, input: StartSyncRunInput = {}): SyncRun {
 }
 
 function finishSyncRunTx(
-  db: DB,
+  db: DBOrTx,
   id: string,
   input: FinishSyncRunInput,
 ): SyncRunSummary {
@@ -188,19 +186,19 @@ function finishSyncRunTx(
   return buildSyncRunSummary(run, items);
 }
 
-export function finishSyncRun(db: DB, id: string, input: FinishSyncRunInput): SyncRunSummary {
-  return db.transaction((tx: TransactionDb) => finishSyncRunTx(tx as unknown as DB, id, input));
+export function finishSyncRun(db: DBOrTx, id: string, input: FinishSyncRunInput): SyncRunSummary {
+  return db.transaction((tx) => finishSyncRunTx(tx, id, input));
 }
 
 export function finishSyncRunWithTx(
-  db: DB,
+  db: DBOrTx,
   id: string,
   input: FinishSyncRunInput,
 ): SyncRunSummary {
   return finishSyncRunTx(db, id, input);
 }
 
-export function getSyncRun(db: DB, id: string): SyncRunSummary | null {
+export function getSyncRun(db: DBOrTx, id: string): SyncRunSummary | null {
   const run = db.select().from(syncRuns).where(eq(syncRuns.id, id)).limit(1).all()[0] ?? null;
   if (!run) {
     return null;
@@ -210,7 +208,7 @@ export function getSyncRun(db: DB, id: string): SyncRunSummary | null {
   return buildSyncRunSummary(run, items);
 }
 
-export function listSyncRuns(db: DB, limit = 10): SyncRunSummary[] {
+export function listSyncRuns(db: DBOrTx, limit = 10): SyncRunSummary[] {
   const runs: SyncRun[] = db
     .select()
     .from(syncRuns)

--- a/packages/task-templates/src/index.ts
+++ b/packages/task-templates/src/index.ts
@@ -1,5 +1,5 @@
 import { eq, asc } from "drizzle-orm";
-import type { DB, TaskTemplate, TaskTemplateStage } from "@clawops/core";
+import type { DBOrTx, TaskTemplate, TaskTemplateStage } from "@clawops/core";
 import { taskTemplates, taskTemplateStages } from "@clawops/core";
 
 // ── Built-in Template Definitions ──────────────────────────────────────────
@@ -64,13 +64,13 @@ const BUILTIN_TEMPLATES = [
 
 // ── listTemplates ───────────────────────────────────────────────────────────
 
-export function listTemplates(db: DB): TaskTemplate[] {
+export function listTemplates(db: DBOrTx): TaskTemplate[] {
   return db.select().from(taskTemplates).all();
 }
 
 // ── getTemplate ─────────────────────────────────────────────────────────────
 
-export function getTemplate(db: DB, id: string): (TaskTemplate & { stages: TaskTemplateStage[] }) | null {
+export function getTemplate(db: DBOrTx, id: string): (TaskTemplate & { stages: TaskTemplateStage[] }) | null {
   const template = db
     .select()
     .from(taskTemplates)
@@ -91,7 +91,7 @@ export function getTemplate(db: DB, id: string): (TaskTemplate & { stages: TaskT
 
 // ── getTemplateByName ───────────────────────────────────────────────────────
 
-export function getTemplateByName(db: DB, name: string): (TaskTemplate & { stages: TaskTemplateStage[] }) | null {
+export function getTemplateByName(db: DBOrTx, name: string): (TaskTemplate & { stages: TaskTemplateStage[] }) | null {
   const template = db
     .select()
     .from(taskTemplates)
@@ -120,7 +120,7 @@ interface CreateTemplateInput {
   stages?: Array<{ name: string; description?: string; order?: number }>;
 }
 
-export function createTemplate(db: DB, input: CreateTemplateInput): TaskTemplate {
+export function createTemplate(db: DBOrTx, input: CreateTemplateInput): TaskTemplate {
   return db.transaction((tx) => {
     const template = tx
       .insert(taskTemplates)
@@ -150,7 +150,7 @@ export function createTemplate(db: DB, input: CreateTemplateInput): TaskTemplate
 
 // ── listTemplateStages ──────────────────────────────────────────────────────
 
-export function listTemplateStages(db: DB, templateId: string): TaskTemplateStage[] {
+export function listTemplateStages(db: DBOrTx, templateId: string): TaskTemplateStage[] {
   return db
     .select()
     .from(taskTemplateStages)
@@ -161,7 +161,7 @@ export function listTemplateStages(db: DB, templateId: string): TaskTemplateStag
 
 // ── getStage ────────────────────────────────────────────────────────────────
 
-export function getStage(db: DB, id: string): TaskTemplateStage | null {
+export function getStage(db: DBOrTx, id: string): TaskTemplateStage | null {
   return db
     .select()
     .from(taskTemplateStages)

--- a/packages/tasks/src/index.ts
+++ b/packages/tasks/src/index.ts
@@ -1,5 +1,5 @@
 import { eq, and, inArray, isNull, asc } from "drizzle-orm";
-import type { DB, Task, Artifact, ResourceLink } from "@clawops/core";
+import type { DBOrTx, Task, Artifact, ResourceLink } from "@clawops/core";
 import { tasks, artifacts, usageLogs, resourceLinks } from "@clawops/core";
 import { calcCost } from "@clawops/domain";
 import { getBlockedTaskIds } from "./relations.js";
@@ -23,7 +23,7 @@ interface CreateTaskInput {
   ideaId?: string;
 }
 
-export function createTask(db: DB, input: CreateTaskInput): Task {
+export function createTask(db: DBOrTx, input: CreateTaskInput): Task {
   const rows = db
     .insert(tasks)
     .values({
@@ -50,7 +50,7 @@ export function createTask(db: DB, input: CreateTaskInput): Task {
 // ── getTask ────────────────────────────────────────────────────────────────
 
 export function getTask(
-  db: DB,
+  db: DBOrTx,
   id: string,
 ): (Task & { artifacts: Artifact[] }) | null {
   const task = db.select().from(tasks).where(eq(tasks.id, id)).get();
@@ -78,7 +78,7 @@ export interface ListTasksFilters {
   stageId?: string;
 }
 
-export function listTasks(db: DB, filters?: ListTasksFilters): Task[] {
+export function listTasks(db: DBOrTx, filters?: ListTasksFilters): Task[] {
   const conditions = [];
 
   if (filters?.status) {
@@ -125,7 +125,7 @@ export interface ListPullableTasksFilters {
   stageId?: string;
 }
 
-export function getPullableTasks(db: DB, filters?: ListPullableTasksFilters): Task[] {
+export function getPullableTasks(db: DBOrTx, filters?: ListPullableTasksFilters): Task[] {
   const conditions = [
     inArray(tasks.status, [...PULLABLE_STATUSES]),
     isNull(tasks.assigneeId),
@@ -169,7 +169,7 @@ interface UpdateTaskInput {
   autoPullEligible?: boolean | null;
 }
 
-export function updateTask(db: DB, id: string, updates: UpdateTaskInput): Task {
+export function updateTask(db: DBOrTx, id: string, updates: UpdateTaskInput): Task {
   const { properties, ...rest } = updates;
   const setClause: Record<string, unknown> = { ...rest };
   if (properties !== undefined) {
@@ -195,7 +195,7 @@ interface CompleteTaskInput {
 }
 
 export function completeTask(
-  db: DB,
+  db: DBOrTx,
   id: string,
   input: CompleteTaskInput,
 ): Task {
@@ -247,14 +247,14 @@ export function completeTask(
 
 // ── getTaskSpec ────────────────────────────────────────────────────────────
 
-export function getTaskSpec(db: DB, id: string): string | null {
+export function getTaskSpec(db: DBOrTx, id: string): string | null {
   const task = db.select().from(tasks).where(eq(tasks.id, id)).get();
   return task?.specContent ?? null;
 }
 
 // ── setTaskSpec ────────────────────────────────────────────────────────────
 
-export function setTaskSpec(db: DB, id: string, specContent: string): Task {
+export function setTaskSpec(db: DBOrTx, id: string, specContent: string): Task {
   const rows = db
     .update(tasks)
     .set({
@@ -270,7 +270,7 @@ export function setTaskSpec(db: DB, id: string, specContent: string): Task {
 // ── appendTaskSpec ─────────────────────────────────────────────────────────
 
 export function appendTaskSpec(
-  db: DB,
+  db: DBOrTx,
   id: string,
   content: string,
 ): Task {
@@ -331,7 +331,7 @@ export interface AddTaskResourceLinkInput {
 }
 
 export function addTaskResourceLink(
-  db: DB,
+  db: DBOrTx,
   taskId: string,
   input: AddTaskResourceLinkInput,
 ): ResourceLink {
@@ -352,7 +352,7 @@ export function addTaskResourceLink(
   return row;
 }
 
-export function listTaskResourceLinks(db: DB, taskId: string): ResourceLink[] {
+export function listTaskResourceLinks(db: DBOrTx, taskId: string): ResourceLink[] {
   return db
     .select()
     .from(resourceLinks)
@@ -362,7 +362,7 @@ export function listTaskResourceLinks(db: DB, taskId: string): ResourceLink[] {
 }
 
 export function removeTaskResourceLink(
-  db: DB,
+  db: DBOrTx,
   taskId: string,
   linkId: string,
 ): ResourceLink | null {

--- a/packages/tasks/src/relations.ts
+++ b/packages/tasks/src/relations.ts
@@ -1,5 +1,5 @@
 import { eq, or, and, inArray } from "drizzle-orm";
-import { taskRelations, tasks, type DB, type TaskRelation, type Task } from "@clawops/core";
+import { taskRelations, tasks, type DBOrTx, type TaskRelation, type Task } from "@clawops/core";
 
 export interface CreateTaskRelationInput {
   fromTaskId: string;
@@ -35,18 +35,18 @@ function chunkArray<T>(items: readonly T[], chunkSize: number): T[][] {
 }
 
 export function createTaskRelation(
-  db: DB,
+  db: DBOrTx,
   input: CreateTaskRelationInput,
 ): TaskRelation {
   return db.insert(taskRelations).values(input).returning().get();
 }
 
-export function deleteTaskRelation(db: DB, id: string): void {
+export function deleteTaskRelation(db: DBOrTx, id: string): void {
   db.delete(taskRelations).where(eq(taskRelations.id, id)).run();
 }
 
 export function listTaskRelations(
-  db: DB,
+  db: DBOrTx,
   taskId: string,
 ): TaskRelationWithTask[] {
   const relations = db
@@ -105,7 +105,7 @@ export function listTaskRelations(
   return results;
 }
 
-export function getBlockersForTask(db: DB, taskId: string): Task[] {
+export function getBlockersForTask(db: DBOrTx, taskId: string): Task[] {
   // Relations where type = "blocks" AND toTaskId = taskId → fromTask is the blocker
   const blockingRelations = db
     .select({
@@ -163,7 +163,7 @@ export function getBlockersForTask(db: DB, taskId: string): Task[] {
   return blockers;
 }
 
-export function isTaskBlocked(db: DB, taskId: string): boolean {
+export function isTaskBlocked(db: DBOrTx, taskId: string): boolean {
   return getBlockersForTask(db, taskId).length > 0;
 }
 
@@ -171,7 +171,7 @@ export function isTaskBlocked(db: DB, taskId: string): boolean {
  * Bulk check: returns the set of task IDs (from the given list) that are
  * actively blocked by at least one non-done/non-cancelled blocker.
  */
-export function getBlockedTaskIds(db: DB, taskIds: string[]): Set<string> {
+export function getBlockedTaskIds(db: DBOrTx, taskIds: string[]): Set<string> {
   if (taskIds.length === 0) return new Set();
 
   const blockingRelations: TaskRelationIds[] = [];
@@ -257,7 +257,7 @@ export function getBlockedTaskIds(db: DB, taskIds: string[]): Set<string> {
  * then fetches blocker completion status in a single follow-up query.
  */
 export function getBlockedAndBlockingIds(
-  db: DB,
+  db: DBOrTx,
   taskIds: string[],
 ): { blockedIds: Set<string>; blockingIds: Set<string> } {
   const blockedIds = new Set<string>();

--- a/packages/workflows/src/engine.ts
+++ b/packages/workflows/src/engine.ts
@@ -1,4 +1,4 @@
-import { createActivityEvent, type DB } from "@clawops/core";
+import { createActivityEvent, type DBOrTx } from "@clawops/core";
 import { createTask, updateTask } from "@clawops/tasks";
 import { createNotification } from "@clawops/notifications";
 import { triggerSupportedOpenClawEndpoint } from "@clawops/sync/openclaw";
@@ -31,7 +31,7 @@ interface StepContext {
   stepResults: Record<string, unknown>;
 }
 
-export function matchEventTrigger(db: DB, eventType: string): WorkflowRecord[] {
+export function matchEventTrigger(db: DBOrTx, eventType: string): WorkflowRecord[] {
   const workflows = listWorkflowDefinitions(db, {
     status: "active",
     triggerType: "event",
@@ -94,7 +94,7 @@ export function evaluateCondition(condition: string, ctx: StepContext): boolean 
 }
 
 async function dispatchAction(
-  db: DB,
+  db: DBOrTx,
   step: WorkflowStepDefinition,
   stepResults: Record<string, unknown>,
 ): Promise<Record<string, unknown>> {
@@ -179,7 +179,7 @@ async function dispatchAction(
 }
 
 export async function executeWorkflow(
-  db: DB,
+  db: DBOrTx,
   workflowId: string,
   input: WorkflowExecutionInput,
 ): Promise<string> {

--- a/packages/workflows/src/index.ts
+++ b/packages/workflows/src/index.ts
@@ -8,7 +8,7 @@ import {
   workflowDefinitions,
   workflowRuns,
   workflowRunSteps,
-  type DB,
+  type DBOrTx,
   type SQL,
   type WorkflowDefinition,
   type WorkflowRun,
@@ -420,7 +420,7 @@ export function validateTriggerConfig(
   }
 }
 
-export function createWorkflowDefinition(db: DB, input: CreateWorkflowInput): WorkflowRecord {
+export function createWorkflowDefinition(db: DBOrTx, input: CreateWorkflowInput): WorkflowRecord {
   const row = db
     .insert(workflowDefinitions)
     .values(normalizeCreateInput(input))
@@ -430,7 +430,7 @@ export function createWorkflowDefinition(db: DB, input: CreateWorkflowInput): Wo
   return toWorkflowRecord(getReturningRow(row, "workflow definition"));
 }
 
-export function getWorkflowDefinition(db: DB, id: string): WorkflowRecord | null {
+export function getWorkflowDefinition(db: DBOrTx, id: string): WorkflowRecord | null {
   const row = db
     .select()
     .from(workflowDefinitions)
@@ -441,7 +441,7 @@ export function getWorkflowDefinition(db: DB, id: string): WorkflowRecord | null
 }
 
 export function listWorkflowDefinitions(
-  db: DB,
+  db: DBOrTx,
   filters: ListWorkflowsFilters = {},
 ): WorkflowRecord[] {
   const whereClause = buildWorkflowFilter(filters);
@@ -451,7 +451,7 @@ export function listWorkflowDefinitions(
 }
 
 export function updateWorkflowDefinition(
-  db: DB,
+  db: DBOrTx,
   id: string,
   input: UpdateWorkflowInput,
 ): WorkflowRecord {
@@ -465,7 +465,7 @@ export function updateWorkflowDefinition(
   return toWorkflowRecord(getReturningRow(row, "workflow definition", "update"));
 }
 
-export function createWorkflowRun(db: DB, input: CreateWorkflowRunInput): WorkflowRunRecord {
+export function createWorkflowRun(db: DBOrTx, input: CreateWorkflowRunInput): WorkflowRunRecord {
   const row = db
     .insert(workflowRuns)
     .values({
@@ -486,7 +486,7 @@ export function createWorkflowRun(db: DB, input: CreateWorkflowRunInput): Workfl
 }
 
 export function updateWorkflowRun(
-  db: DB,
+  db: DBOrTx,
   id: string,
   input: UpdateWorkflowRunInput,
 ): WorkflowRunRecord {
@@ -508,7 +508,7 @@ export function updateWorkflowRun(
   return toWorkflowRunRecord(getReturningRow(row, "workflow run", "update"));
 }
 
-export function listWorkflowRuns(db: DB, workflowId: string): WorkflowRunRecord[] {
+export function listWorkflowRuns(db: DBOrTx, workflowId: string): WorkflowRunRecord[] {
   return db
     .select()
     .from(workflowRuns)
@@ -518,7 +518,7 @@ export function listWorkflowRuns(db: DB, workflowId: string): WorkflowRunRecord[
     .map(toWorkflowRunRecord);
 }
 
-export function getWorkflowRun(db: DB, id: string): WorkflowRunWithSteps | null {
+export function getWorkflowRun(db: DBOrTx, id: string): WorkflowRunWithSteps | null {
   const run = db.select().from(workflowRuns).where(eq(workflowRuns.id, id)).get();
   if (!run) {
     return null;
@@ -531,7 +531,7 @@ export function getWorkflowRun(db: DB, id: string): WorkflowRunWithSteps | null 
 }
 
 export function createWorkflowRunStep(
-  db: DB,
+  db: DBOrTx,
   input: CreateWorkflowRunStepInput,
 ): WorkflowStepRunRecord {
   const row = db
@@ -556,7 +556,7 @@ export function createWorkflowRunStep(
 }
 
 export function updateWorkflowRunStep(
-  db: DB,
+  db: DBOrTx,
   id: string,
   input: UpdateWorkflowRunStepInput,
 ): WorkflowStepRunRecord {
@@ -578,7 +578,7 @@ export function updateWorkflowRunStep(
 }
 
 export function listWorkflowRunSteps(
-  db: DB,
+  db: DBOrTx,
   workflowRunId: string,
 ): WorkflowStepRunRecord[] {
   return db


### PR DESCRIPTION
~50 API handlers cast drizzle transactions as 'tx as unknown as DB'. Fix by exporting a DBOrTx union type from @clawops/core and updating all domain function signatures to accept DBOrTx. This eliminates all unsafe casts. Must pass pnpm check after.

Closes #https://github.com/hishamank/clawops/issues/185

## Plan

# Implementation Plan: DBOrTx Union Type Export

## Problem

~50 API handlers cast drizzle transactions as `tx as unknown as DB`. This is unsafe and bypasses TypeScript's type safety.

## Solution

Create and export a `DBOrTx` union type from `@clawops/core` that accepts both `DB` and transaction objects, then update all domain function signatures to use this type.

---

## Files to Modify

### 1. `packages/core/src/db.ts`
- **Change:** Add `TransactionDb` type derived from Drizzle's transaction callback parameter
- **Change:** Create `DBOrTx` union type: `DB | TransactionDb`
- **Why:** Central type definition for use across all packages

### 2. `packages/core/src/index.ts`
- **Change:** Export `DBOrTx` type
- **Why:** Make it available to all consumers of @clawops/core

### 3. Domain package function signatures (50+ functions across 12 packages)
Update all functions that accept `db: DB` to accept `db: DBOrTx`:

| Package | Files |
|---------|-------|
| `@clawops/tasks` | `src/index.ts`, `src/relations.ts` |
| `@clawops/projects` | `src/index.ts` |
| `@clawops/ideas` | `src/index.ts` |
| `@clawops/habits` | `src/index.ts`, `src/openclaw.ts` |
| `@clawops/agents` | `src/index.ts` |
| `@clawops/notifications` | `src/index.ts` |
| `@clawops/analytics` | `src/index.ts` |
| `@clawops/sync` | `src/runs.ts`, `src/connections.ts`, `src/events.ts`, `src/openclaw/*.ts` |
| `@clawops/workflows` | `src/index.ts`, `src/engine.ts` |
| `@clawops/task-templates` | `src/index.ts` |
| `@clawops/core` | `src/helpers.ts` (createActivityEvent, workflow functions) |
| `@clawops/cli` | `src/lib/client.ts` |

### 4. API Route handlers in `apps/web/app/api/**/route.ts`
- **Change:** Remove `as unknown as DB` casts from transaction callbacks
- **Why:** No longer needed when passing `tx` directly to functions accepting `DBOrTx`

---

## Implementation Order

1. **Modify core DB types** (`packages/core/src/db.ts`): Add `TransactionDb` and `DBOrTx` types
2. **Export from core** (`packages/core/src/index.ts`): Export `DBOrTx`
3. **Update helpers in core** (`packages/core/src/helpers.ts`): Update all functions to use `DBOrTx`
4. **Update each domain package** (in dependency order):
   - `@clawops/domain` (if needed)
   - `@clawops/core` (helpers)
   - `@clawops/tasks`
   - `@clawops/projects`
   - `@clawops/ideas`
   - `@clawops/habits`
   - `@clawops/agents`
   - `@clawops/notifications`
   - `@clawops/task-templates`
   - `@clawops/workflows`
   - `@clawops/analytics`
   - `@clawops/sync`
5. **Update API routes** (`apps/web/app/api/**/route.ts`): Remove unsafe casts
6. **Run `pnpm check`** to verify all types pass

---

## Testing Strategy

- **No new tests needed**: This is a type-only change
- **Existing tests should pass**: Tests use the same function signatures
- **Run `pnpm check`** after all changes to verify:
  - `pnpm typecheck` passes
  - `pnpm lint` passes
  - `pnpm build` passes

---

## Risks and Edge Cases

1. **Breaking change for consumers**: Any external code

_(truncated)_

---
_Automated by rick-tasks (task_009)_