### PR TITLE
fix: add error.tsx boundaries for workflows/[id], workflows/new, openclaw/files pages

### DIFF
--- a/apps/web/app/openclaw/files/[fileId]/compare/error.tsx
+++ b/apps/web/app/openclaw/files/[fileId]/compare/error.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}): React.JSX.Element {
+  useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center py-24 text-center">
+      <AlertTriangle className="h-10 w-10 text-rose-400 mb-4" />
+      <h2 className="text-lg font-semibold mb-2">Something went wrong</h2>
+      <p className="text-sm text-muted-foreground mb-6 max-w-sm">
+        {error.message ?? "An unexpected error occurred. Please try again."}
+      </p>
+      <Button variant="outline" onClick={reset} className="rounded-xl">
+        Try again
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/app/openclaw/files/[fileId]/error.tsx
+++ b/apps/web/app/openclaw/files/[fileId]/error.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}): React.JSX.Element {
+  useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center py-24 text-center">
+      <AlertTriangle className="h-10 w-10 text-rose-400 mb-4" />
+      <h2 className="text-lg font-semibold mb-2">Something went wrong</h2>
+      <p className="text-sm text-muted-foreground mb-6 max-w-sm">
+        {error.message ?? "An unexpected error occurred. Please try again."}
+      </p>
+      <Button variant="outline" onClick={reset} className="rounded-xl">
+        Try again
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/app/workflows/[id]/error.tsx
+++ b/apps/web/app/workflows/[id]/error.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}): React.JSX.Element {
+  useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center py-24 text-center">
+      <AlertTriangle className="h-10 w-10 text-rose-400 mb-4" />
+      <h2 className="text-lg font-semibold mb-2">Something went wrong</h2>
+      <p className="text-sm text-muted-foreground mb-6 max-w-sm">
+        {error.message ?? "An unexpected error occurred. Please try again."}
+      </p>
+      <Button variant="outline" onClick={reset} className="rounded-xl">
+        Try again
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/app/workflows/new/error.tsx
+++ b/apps/web/app/workflows/new/error.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}): React.JSX.Element {
+  useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center py-24 text-center">
+      <AlertTriangle className="h-10 w-10 text-rose-400 mb-4" />
+      <h2 className="text-lg font-semibold mb-2">Something went wrong</h2>
+      <p className="text-sm text-muted-foreground mb-6 max-w-sm">
+        {error.message ?? "An unexpected error occurred. Please try again."}
+      </p>
+      <Button variant="outline" onClick={reset} className="rounded-xl">
+        Try again
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
4 new pages missing error.tsx siblings: app/workflows/[id]/, app/workflows/new/, app/openclaw/files/[fileId]/, app/openclaw/files/[fileId]/compare/. Add error.tsx with 'use client', error + reset props, friendly UI and retry button to each.

Closes #https://github.com/hishamank/clawops/issues/189

## Plan

# Plan: Add error.tsx boundaries for workflows/[id], workflows/new, openclaw/files/[fileId]/, openclaw/files/[fileId]/compare/

## Overview

Add error boundary components (`error.tsx`) to 4 pages that are currently missing them:

1. `app/workflows/[id]/error.tsx` - Workflow detail page
2. `app/workflows/new/error.tsx` - New workflow creation page  
3. `app/openclaw/files/[fileId]/error.tsx` - File detail/revisions page
4. `app/openclaw/files/[fileId]/compare/error.tsx` - File revision comparison page

## Files to Create

### 1. `apps/web/app/workflows/[id]/error.tsx`

**Purpose:** Error boundary for the workflow detail page (`app/workflows/[id]/page.tsx`)

**Content:** Follow the existing pattern from `app/workflows/page.tsx` siblings (e.g., `app/tasks/error.tsx`):
- `"use client"` directive
- `error` and `reset` props
- Friendly error UI with icon, message, and retry button
- Uses `AlertTriangle` from lucide-react
- Uses `Button` component from `@/components/ui/button`

### 2. `apps/web/app/workflows/new/error.tsx`

**Purpose:** Error boundary for the new workflow creation page

**Content:** Same pattern as above, consistent with other error boundaries in the app

### 3. `apps/web/app/openclaw/files/[fileId]/error.tsx`

**Purpose:** Error boundary for the file detail/revision history page

**Content:** Same standard pattern - can optionally include a "Back to OpenClaw" link like the agent error page does

### 4. `apps/web/app/openclaw/files/[fileId]/compare/error.tsx`

**Purpose:** Error boundary for the file revision comparison page

**Content:** Same standard pattern - can optionally include a "Back to File Revisions" link

## Implementation Details

### Pattern to Follow

All error boundaries will follow the established pattern from existing error.tsx files:

```tsx
"use client";

import { useEffect } from "react";
import { AlertTriangle } from "lucide-react";
import { Button } from "@/components/ui/button";

export default function Error({
  error,
  reset,
}: {
  error: Error & { digest?: string };
  reset: () => void;
}): React.JSX.Element {
  useEffect(() => {
    // eslint-disable-next-line no-console
    console.error(error);
  }, [error]);

  return (
    <div className="flex flex-col items-center justify-center py-24 text-center">
      <AlertTriangle className="h-10 w-10 text-rose-400 mb-4" />
      <h2 className="text-lg font-semibold mb-2">Something went wrong</h2>
      <p className="text-sm text-muted-foreground mb-6 max-w-sm">
        {error.message ?? "An unexpected error occurred. Please try again."}
      </p>
      <Button variant="outline" onClick={reset} className="rounded-xl">
        Try again
      </Button>
    </div>
  );
}
```

### Optional Enhancement for Nested Routes

For the `[fileId]` routes, consider adding navigation links back to parent routes (similar to `app/agents/[id]/error.tsx`):
- `app/openclaw/files/[fileId]/error.tsx` → Add "Back to OpenClaw" link
- `app/openclaw/files/[fileId]/compare/error.tsx` → Ad

_(truncated)_

---
_Automated by rick-tasks (task_013)_